### PR TITLE
feat: detect various fixture errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,13 +81,11 @@ class FixturesImpl<WorkerParameters, WorkerFixtures, TestFixtures> {
   }
 
   defineTestFixture<T extends keyof TestFixtures>(name: T | '*', fn: (params: WorkerParameters & WorkerFixtures & TestFixtures, runTest: (arg: TestFixtures[T]) => Promise<void>) => Promise<void>, options: FixtureDefinitionOptions = {}) {
-    // TODO: make this throw when overriding.
-    registerFixture(name as string, fn, options);
+    registerFixture(name as string, fn, options, false);
   }
 
   overrideTestFixture<T extends keyof TestFixtures>(name: T, fn: (params: WorkerParameters & WorkerFixtures & TestFixtures, runTest: (arg: TestFixtures[T]) => Promise<void>) => Promise<void>, options: FixtureDefinitionOptions = {}) {
-    // TODO: make this throw when not overriding.
-    registerFixture(name as string, fn, options);
+    registerFixture(name as string, fn, options, true);
   }
 
   declareWorkerFixtures<W>(): Fixtures<WorkerParameters, WorkerFixtures & W, TestFixtures> {
@@ -95,13 +93,11 @@ class FixturesImpl<WorkerParameters, WorkerFixtures, TestFixtures> {
   }
 
   defineWorkerFixture<T extends keyof WorkerFixtures>(name: T | '*', fn: (params: WorkerParameters & WorkerFixtures, runTest: (arg: WorkerFixtures[T]) => Promise<void>) => Promise<void>, options: FixtureDefinitionOptions = {}) {
-    // TODO: make this throw when overriding.
-    registerWorkerFixture(name as string, fn, options);
+    registerWorkerFixture(name as string, fn, options, false);
   }
 
   overrideWorkerFixture<T extends keyof WorkerFixtures>(name: T, fn: (params: WorkerParameters & WorkerFixtures, runTest: (arg: WorkerFixtures[T]) => Promise<void>) => Promise<void>, options: FixtureDefinitionOptions = {}) {
-    // TODO: make this throw when not overriding.
-    registerWorkerFixture(name as string, fn, options);
+    registerWorkerFixture(name as string, fn, options, true);
   }
 
   declareParameters<P>(): Fixtures<WorkerParameters & P, WorkerFixtures, TestFixtures> {
@@ -114,7 +110,7 @@ class FixturesImpl<WorkerParameters, WorkerFixtures, TestFixtures> {
       description,
       defaultValue: defaultValue as any,
     });
-    registerWorkerFixture(name as string, async ({}, runTest) => runTest(defaultValue), {});
+    registerWorkerFixture(name as string, async ({}, runTest) => runTest(defaultValue), {}, false);
   }
 
   generateParametrizedTests<T extends keyof WorkerParameters>(name: T, values: WorkerParameters[T][]) {

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import rimraf from 'rimraf';
 import { promisify } from 'util';
 import { Dispatcher } from './dispatcher';
-import { config, assignConfig, matrix, ParameterRegistration, parameterRegistrations, setParameterValues } from './fixtures';
+import { config, assignConfig, matrix, ParameterRegistration, parameterRegistrations, setParameterValues, validateRegistrations } from './fixtures';
 import { Reporter } from './reporter';
 import { Config } from './config';
 import { generateTests } from './testGenerator';
@@ -57,6 +57,7 @@ export class Runner {
       const revertBabelRequire = runnerSpec(suite, config.timeout);
       try {
         require(file);
+        validateRegistrations(file);
         this._suites.push(suite);
       } catch (error) {
         this._reporter.onError(serializeError(error), file);

--- a/src/workerRunner.ts
+++ b/src/workerRunner.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { FixturePool, rerunRegistrations, assignParameters, TestInfo, parameters, assignConfig, config } from './fixtures';
+import { FixturePool, validateRegistrations, assignParameters, TestInfo, parameters, assignConfig, config } from './fixtures';
 import { EventEmitter } from 'events';
 import { WorkerSpec, WorkerSuite } from './workerTest';
 import { Config } from './config';
@@ -113,7 +113,7 @@ export class WorkerRunner extends EventEmitter {
     this._suite._assignIds(this._parametersString);
     this._loaded = true;
 
-    rerunRegistrations(this._suite.file);
+    validateRegistrations(this._suite.file);
     await this._runSuite(this._suite);
     this._reportDone();
   }

--- a/test/fixture-errors.spec.ts
+++ b/test/fixture-errors.spec.ts
@@ -26,11 +26,11 @@ it('should handle fixture timeout', async ({ runInlineFixturesTest }) => {
         await runTest();
         await new Promise(f => setTimeout(f, 100000));
       });
-      
+
       it('fixture timeout', async ({timeout}) => {
         expect(1).toBe(1);
       });
-      
+
       it('failing fixture timeout', async ({timeout}) => {
         expect(1).toBe(2);
       });
@@ -49,7 +49,7 @@ it('should handle worker fixture timeout', async ({ runInlineFixturesTest }) => 
 
       defineWorkerFixture('timeout', async ({}, runTest) => {
       });
-      
+
       it('fails', async ({timeout}) => {
       });
     `
@@ -66,9 +66,9 @@ it('should handle worker fixture error', async ({ runInlineFixturesTest }) => {
       defineWorkerFixture('failure', async ({}, runTest) => {
         throw new Error('Worker failed');
       });
-      
+
       it('fails', async ({failure}) => {
-      });    
+      });
     `
   });
   expect(result.exitCode).toBe(1);
@@ -85,12 +85,199 @@ it('should handle worker tear down fixture error', async ({ runInlineFixturesTes
         await runTest();
         throw new Error('Worker failed');
       });
-      
+
       it('pass', async ({failure}) => {
         expect(true).toBe(true);
-      });    
+      });
     `
   });
   expect(result.report.errors[0].error.message).toContain('Worker failed');
+  expect(result.exitCode).toBe(1);
+});
+
+it('should throw when overriding non-defined worker fixture', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'a.spec.ts': `
+      const { it, overrideWorkerFixture } = baseFixtures;
+      overrideWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `
+  });
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has not been registered yet. Use defineWorkerFixture instead.');
+  expect(result.exitCode).toBe(1);
+});
+
+it('should throw when defining worker fixture twice', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'b.spec.ts': `
+      const { it, defineWorkerFixture } = baseFixtures;
+      defineWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      defineWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `
+  });
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has already been registered. Use overrideWorkerFixture to override it in a specific test file.');
+  expect(result.exitCode).toBe(1);
+});
+
+it('should throw when overriding non-defined test fixture', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'c.spec.ts': `
+      const { it, overrideTestFixture } = baseFixtures;
+      overrideTestFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `
+  });
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has not been registered yet. Use defineTestFixture instead.');
+  expect(result.exitCode).toBe(1);
+});
+
+it('should throw when defining test fixture twice', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'd.spec.ts': `
+      const { it, defineTestFixture } = baseFixtures;
+      defineTestFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      defineTestFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `
+  });
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has already been registered. Use overrideTestFixture to override it in a specific test file.');
+  expect(result.exitCode).toBe(1);
+});
+
+it('should throw when defining test fixture with the same name as a worker fixture', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'e.spec.ts': `
+      const { it, defineTestFixture, defineWorkerFixture } = baseFixtures;
+      defineWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      defineTestFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `,
+  });
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has already been registered as a worker fixture. Use a different name for this test fixture.');
+  expect(result.exitCode).toBe(1);
+});
+
+it('should throw when defining worker fixture with the same name as a test fixture', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'e.spec.ts': `
+      const { it, defineTestFixture, defineWorkerFixture } = baseFixtures;
+      defineTestFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      defineWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `,
+  });
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has already been registered as a test fixture. Use a different name for this worker fixture.');
+  expect(result.exitCode).toBe(1);
+});
+
+it('should throw when overriding worker fixture as a test fixture', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'f.spec.ts': `
+      const { it, overrideTestFixture, defineWorkerFixture } = baseFixtures;
+      defineWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      overrideTestFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `,
+  });
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" is a worker fixture. Use overrideWorkerFixture instead.');
+  expect(result.exitCode).toBe(1);
+});
+
+it('should throw when overriding test fixture as a worker fixture', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'f.spec.ts': `
+      const { it, overrideWorkerFixture, defineTestFixture } = baseFixtures;
+      defineTestFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      overrideWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `,
+  });
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" is a test fixture. Use overrideTestFixture instead.');
+  expect(result.report.errors[0].error.stack).toContain('f.spec.ts:8');
+  expect(result.exitCode).toBe(1);
+});
+
+it('should define and override the same fixture in two files', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'a.spec.ts': `
+      const { it, defineWorkerFixture, overrideWorkerFixture } = baseFixtures;
+      defineWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      overrideWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `,
+    'b.spec.ts': `
+      const { it, defineWorkerFixture, overrideWorkerFixture } = baseFixtures;
+      defineWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      overrideWorkerFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `,
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.passed).toBe(2);
+});
+
+it('should detect fixture dependency cycle', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'x.spec.ts': `
+      const { it, defineTestFixture } = baseFixtures;
+      defineTestFixture('good1', async ({}, runTest) => {
+        await runTest();
+      });
+      defineTestFixture('foo', async ({bar}, runTest) => {
+        await runTest();
+      });
+      defineTestFixture('bar', async ({baz}, runTest) => {
+        await runTest();
+      });
+      defineTestFixture('good2', async ({good1}, runTest) => {
+        await runTest();
+      });
+      defineTestFixture('baz', async ({qux}, runTest) => {
+        await runTest();
+      });
+      defineTestFixture('qux', async ({foo}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({foo}) => {});
+    `,
+  });
+  expect(result.report.errors[0].error.message).toContain('Fixtures "foo" -> "bar" -> "baz" -> "qux" -> "foo" form a dependency cycle.');
   expect(result.exitCode).toBe(1);
 });


### PR DESCRIPTION
- overriding of non-existent fixture;
- defining a fixture twice;
- worker fixture depending on test fixture;
- dependency cycle.

Drive-by: use registration id instead of location when computing hash.

References #9.