### PR TITLE
fix(hooks): call all the hooks before fixtures teardown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1067,8 +1067,8 @@
       }
     },
     "@playwright/test-runner": {
-      "version": "file:https:/registry.npmjs.org/@playwright/test-runner/-/test-runner-0.9.11.tgz",
-      "integrity": "sha512-z0/tj0RVqIUaRggOuyU50cFfyNNcQNvAnMk8rhGiJ3EHsqIe63lgxAlVwNUAkpRGVZdvT8XJDkG4pef4lyLtSQ==",
+      "version": "file:stable-test-runner/node_modules/@playwright/test-runner",
+      "integrity": "sha512-dbuF01oydF3uV6K24LnFpy6CIRULIjZK4YainHPgpmjDBpU5/BukTdW6xcJDHPSj4hbs9ycIDHvz6YCS5pMxew==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -54,7 +54,7 @@ export class Runner {
     for (const file of files) {
       const suite = new RunnerSuite('');
       suite.file = file;
-      const revertBabelRequire = runnerSpec(suite, config.timeout);
+      const revertBabelRequire = runnerSpec(suite, config.timeout, file);
       try {
         require(file);
         validateRegistrations(file);

--- a/src/util.ts
+++ b/src/util.ts
@@ -88,3 +88,20 @@ export function monotonicTime(): number {
   const [seconds, nanoseconds] = process.hrtime();
   return seconds * 1000 + (nanoseconds / 1000000 | 0);
 }
+
+export function callerFile(caller: Function, stackFrameIndex: number): string {
+  const obj = { stack: '' };
+  // disable source-map-support to match the locations seen in require.cache
+  const origPrepare = Error.prepareStackTrace;
+  Error.prepareStackTrace = null;
+  Error.captureStackTrace(obj, caller);
+  // v8 doesn't actually prepare the stack trace until we access it
+  obj.stack;
+  Error.prepareStackTrace = origPrepare;
+  let stackFrame = obj.stack.split('\n')[stackFrameIndex].trim();
+  if (stackFrame.startsWith('at '))
+    stackFrame = stackFrame.substring(3);
+  if (stackFrame.includes('('))
+    stackFrame = stackFrame.match(/\((.*)\)/)[1];
+  return stackFrame.replace(/^(.+):\d+:\d+$/, '$1');
+}

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright Microsoft Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from '@playwright/test-runner';
+import { fixtures } from './fixtures';
+const { it } = fixtures;
+
+it('hooks should work with fixtures', async ({ runInlineTest }) => {
+  const { results } = await runInlineTest({
+    'a.test.js': `
+      const logs = [];
+      fixtures.defineWorkerFixture('w', async ({}, test) => {
+        logs.push('+w');
+        await test(17);
+        logs.push('-w');
+      });
+      fixtures.defineTestFixture('t', async ({}, test) => {
+        logs.push('+t');
+        await test(42);
+        logs.push('-t');
+      });
+
+      describe('suite', () => {
+        fixtures.beforeAll(async ({w}) => {
+          logs.push('beforeAll-' + w);
+        });
+        fixtures.afterAll(async ({w}) => {
+          logs.push('afterAll-' + w);
+        });
+
+        fixtures.beforeEach(async ({w, t}) => {
+          logs.push('beforeEach-' + w + '-' + t);
+        });
+        fixtures.afterEach(async ({w, t}) => {
+          logs.push('afterEach-' + w + '-' + t);
+        });
+
+        it('one', async ({w, t}) => {
+          logs.push('test');
+          expect(w).toBe(17);
+          expect(t).toBe(42);
+        });
+      });
+
+      it('two', async ({w}) => {
+        expect(logs).toEqual([
+          '+w',
+          'beforeAll-17',
+          '+t',
+          'beforeEach-17-42',
+          'test',
+          'afterEach-17-42',
+          '-t',
+          'afterAll-17',
+        ]);
+      });
+    `,
+  });
+  expect(results[0].status).toBe('passed');
+});
+
+it('afterEach failure should not prevent other hooks and fixture teardown', async ({ runInlineTest }) => {
+  const report = await runInlineTest({
+    'a.test.js': `
+      fixtures.defineTestFixture('t', async ({}, test) => {
+        console.log('+t');
+        await test(42);
+        console.log('-t');
+      });
+      fixtures.afterEach(async ({}) => {
+        console.log('afterEach1');
+      });
+      fixtures.afterEach(async ({}) => {
+        console.log('afterEach2');
+        throw new Error('afterEach2');
+      });
+      it('one', async ({t}) => {
+        console.log('test');
+        expect(t).toBe(42);
+      });
+    `,
+  });
+  expect(report.output).toContain('+t\ntest\nafterEach2\nafterEach1\n-t');
+  expect(report.results[0].error.message).toContain('afterEach2');
+});
+
+it('beforeEach failure should prevent the test, but not other hooks', async ({ runInlineTest }) => {
+  const report = await runInlineTest({
+    'a.test.js': `
+      fixtures.beforeEach(async ({}) => {
+        console.log('beforeEach1');
+      });
+      fixtures.beforeEach(async ({}) => {
+        console.log('beforeEach2');
+        throw new Error('beforeEach2');
+      });
+      fixtures.afterEach(async ({}) => {
+        console.log('afterEach');
+      });
+      it('one', async ({}) => {
+        console.log('test');
+      });
+    `,
+  });
+  expect(report.output).toContain('beforeEach1\nbeforeEach2\nafterEach');
+  expect(report.results[0].error.message).toContain('beforeEach2');
+});
+
+it('should throw when hook is called in fixutres file', async ({ runInlineTest }) => {
+  const report = await runInlineTest({
+    'fixture.js': `
+      fixtures.beforeEach(async ({}) => {});
+    `,
+    'a.test.js': `
+      require('./fixture.js');
+      it('test', async ({}) => {
+      });
+    `,
+  });
+  expect(report.report.errors[0].error.message).toContain('beforeEach hook should be called from the test file.');
+});


### PR DESCRIPTION
This fixes multiple issues:
- afterEach hooks are now called before fixtures teardown;
- error in a hook does not prevent other hooks from running;
- error in before hooks blocks the test, but not after hooks or fixtures teardown;
- throwing when hook is used outside of a test file.

References #9.