### PR TITLE
feat(hooks): validate hook fixtures dependencies

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import rimraf from 'rimraf';
 import { promisify } from 'util';
 import { Dispatcher } from './dispatcher';
-import { config, assignConfig, matrix, ParameterRegistration, parameterRegistrations, setParameterValues, validateRegistrations } from './fixtures';
+import { config, assignConfig, matrix, ParameterRegistration, parameterRegistrations, setParameterValues, validateRegistrations, validateFixturesForFunction } from './fixtures';
 import { Reporter } from './reporter';
 import { Config } from './config';
 import { generateTests } from './testGenerator';
@@ -58,6 +58,10 @@ export class Runner {
       try {
         require(file);
         validateRegistrations(file);
+        suite.findSuite(s => {
+          for (const hook of (s as RunnerSuite)._hooks)
+            validateFixturesForFunction(hook.fn, hook.stack, hook.type + ' hook', hook.type === 'beforeEach' || hook.type === 'afterEach');
+        });
         this._suites.push(suite);
       } catch (error) {
         this._reporter.onError(serializeError(error), file);

--- a/src/runnerTest.ts
+++ b/src/runnerTest.ts
@@ -29,6 +29,7 @@ export class RunnerSpec extends Spec {
 
 export class RunnerSuite extends Suite {
   _modifierFn: ModifierFn | null;
+  _hooks: { type: string, fn: Function, stack: string } [] = [];
 
   constructor(title: string, parent?: RunnerSuite) {
     super(title, parent);
@@ -39,6 +40,10 @@ export class RunnerSuite extends Suite {
       for (const run of test.tests as RunnerTest[])
         run._id = `${test._ordinal}@${run.spec.file}::[${run._parametersString}]`;
     });
+  }
+
+  _addHook(type: string, fn: any, stack: string) {
+    this._hooks.push({ type, fn, stack });
   }
 }
 

--- a/test/fixture-errors.spec.ts
+++ b/test/fixture-errors.spec.ts
@@ -226,6 +226,23 @@ it('should throw when overriding test fixture as a worker fixture', async ({ run
   expect(result.exitCode).toBe(1);
 });
 
+it('should throw when worker fixture depends on a test fixture', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'f.spec.ts': `
+      const { it, defineWorkerFixture, defineTestFixture } = baseFixtures;
+      defineTestFixture('foo', async ({}, runTest) => {
+        await runTest();
+      });
+      defineWorkerFixture('bar', async ({foo}, runTest) => {
+        await runTest();
+      });
+      it('works', async ({bar}) => {});
+    `,
+  });
+  expect(result.report.errors[0].error.message).toContain('Worker fixture "bar" cannot depend on a test fixture "foo".');
+  expect(result.exitCode).toBe(1);
+});
+
 it('should define and override the same fixture in two files', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `


### PR DESCRIPTION
- Throw for unknown fixture.
- Throw when beforeAll/afterAll depends on a test fixture.

References #9.