### PR TITLE
feat(fixtures): new fixtures syntax

### DIFF
--- a/src/fixtures.ts
+++ b/src/fixtures.ts
@@ -342,11 +342,11 @@ export function validateRegistrations(file: string): string {
       if (previous.scope !== registration.scope)
         throw errorWithStack(registration.stack, `Fixture "${registration.name}" has already been registered as a ${previous.scope} fixture. Use a different name for this ${registration.scope} fixture.`);
       else
-        throw errorWithStack(registration.stack, `Fixture "${registration.name}" has already been registered. Use ${registration.scope === 'test' ? 'overrideTestFixture' : 'overrideWorkerFixture'} to override it in a specific test file.`);
+        throw errorWithStack(registration.stack, `Fixture "${registration.name}" has already been registered. Use ${registration.scope === 'test' ? 'overrideTestFixtures' : 'overrideWorkerFixtures'} to override it in a specific test file.`);
     } else if (registration.isOverride && !previous) {
-      throw errorWithStack(registration.stack, `Fixture "${registration.name}" has not been registered yet. Use ${registration.scope === 'test' ? 'defineTestFixture' : 'defineWorkerFixture'} instead.`);
+      throw errorWithStack(registration.stack, `Fixture "${registration.name}" has not been registered yet. Use ${registration.scope === 'test' ? 'defineTestFixtures' : 'defineWorkerFixtures'} instead.`);
     } else if (registration.isOverride && previous && previous.scope !== registration.scope) {
-      throw errorWithStack(registration.stack, `Fixture "${registration.name}" is a ${previous.scope} fixture. Use ${previous.scope === 'test' ? 'overrideTestFixture' : 'overrideWorkerFixture'} instead.`);
+      throw errorWithStack(registration.stack, `Fixture "${registration.name}" is a ${previous.scope} fixture. Use ${previous.scope === 'test' ? 'overrideTestFixtures' : 'overrideWorkerFixtures'} instead.`);
     }
     registrations.set(registration.name, registration);
     if (registration.scope === 'worker')

--- a/test/assets/export-1.fixtures.ts
+++ b/test/assets/export-1.fixtures.ts
@@ -23,14 +23,12 @@ type WrapTestState = {
   testWrap: string;
 };
 
-export const fixtures1 = baseFixtures
-    .declareWorkerFixtures<WrapWorkerState>()
-    .declareTestFixtures<WrapTestState>();
-
-fixtures1.defineTestFixture('testWrap', async ({}, runTest) => {
-  await runTest('testWrap');
-});
-
-fixtures1.defineWorkerFixture('workerWrap', async ({}, runTest) => {
-  await runTest(42);
+export const fixtures1 = baseFixtures.defineTestFixtures<WrapTestState>({
+  testWrap: async ({}, runTest) => {
+    await runTest('testWrap');
+  }
+}).defineWorkerFixtures<WrapWorkerState>({
+  workerWrap: async ({}, runTest) => {
+    await runTest(42);
+  }
 });

--- a/test/assets/export-2.fixtures.ts
+++ b/test/assets/export-2.fixtures.ts
@@ -23,14 +23,12 @@ type TypeOnlyWorkerState = {
   workerTypeOnly: number;
 };
 
-export const fixtures2 = baseFixtures
-    .declareWorkerFixtures<TypeOnlyWorkerState>()
-    .declareTestFixtures<TypeOnlyTestState>();
-
-fixtures2.defineTestFixture('testTypeOnly', async ({}, runTest) => {
-  await runTest('testTypeOnly');
-});
-
-fixtures2.defineWorkerFixture('workerTypeOnly', async ({}, runTest) => {
-  await runTest(42);
+export const fixtures2 = baseFixtures.defineTestFixtures<TypeOnlyTestState>({
+  testTypeOnly: async ({}, runTest) => {
+    await runTest('testTypeOnly');
+  }
+}).defineWorkerFixtures<TypeOnlyWorkerState>({
+  workerTypeOnly: async ({}, runTest) => {
+    await runTest(42);
+  }
 });

--- a/test/assets/import-fixtures-both.ts
+++ b/test/assets/import-fixtures-both.ts
@@ -16,14 +16,16 @@
 
 import { fixtures1 } from './export-1.fixtures';
 import { fixtures2 } from './export-2.fixtures';
-const { overrideTestFixture, overrideWorkerFixture, it, expect } = fixtures1.union(fixtures2);
 
-overrideTestFixture('testWrap', async ({}, runTest) => {
-  await runTest('override');
-});
-
-overrideWorkerFixture('workerTypeOnly', async ({}, runTest) => {
-  await runTest(17);
+const fixtures = fixtures1.union(fixtures2);
+const { it, expect } = fixtures.overrideTestFixtures({
+  testWrap: async ({}, runTest) => {
+    await runTest('override');
+  }
+}).overrideWorkerFixtures({
+  workerTypeOnly: async ({}, runTest) => {
+    await runTest(17);
+  }
 });
 
 it('ensure that overrides work', async ({ testTypeOnly, workerTypeOnly, testWrap, workerWrap }) => {

--- a/test/assets/register-parameter.ts
+++ b/test/assets/register-parameter.ts
@@ -16,22 +16,17 @@
 
 import { fixtures as baseFixtures, expect } from '../..';
 
-type Parameters = {
-  param1: string;
-  param2: string;
-};
-
-const fixtures = baseFixtures.declareParameters<Parameters>().declareTestFixtures<{ fixture1: string, fixture2: string}>();
-fixtures.defineParameter('param1', 'Custom parameter 1', '');
-fixtures.defineParameter('param2', 'Custom parameter 2', 'value2');
-fixtures.defineTestFixture('fixture1', async ({testInfo}, runTest) => {
-  await runTest(testInfo.parameters.param1 as string);
-});
-fixtures.defineTestFixture('fixture2', async ({testInfo}, runTest) => {
-  await runTest(testInfo.parameters.param2 as string);
-});
-
-const { it } = fixtures;
+const { it } = baseFixtures
+    .defineParameter('param1', 'Custom parameter 1', '')
+    .defineParameter('param2', 'Custom parameter 2', 'value2')
+    .defineTestFixtures<{ fixture1: string, fixture2: string}>({
+      fixture1: async ({testInfo}, runTest) => {
+        await runTest(testInfo.parameters.param1 as string);
+      },
+      fixture2: async ({testInfo}, runTest) => {
+        await runTest(testInfo.parameters.param2 as string);
+      },
+    });
 
 it('pass', async ({ param1, param2, fixture1, fixture2 }) => {
   // Available as fixtures.

--- a/test/assets/test-data-visible-in-fixture.ts
+++ b/test/assets/test-data-visible-in-fixture.ts
@@ -16,13 +16,11 @@
 
 import { config, fixtures, TestInfo } from '../../';
 
-const { it, expect, defineTestFixture } = fixtures
-    .declareTestFixtures<{ testInfoForward: TestInfo }>()
-    .declareWorkerFixtures<{ config: any }>();
-
-defineTestFixture('testInfoForward', async ({ testInfo }, runTest) => {
-  await runTest(testInfo);
-  testInfo.data['myname'] = 'myvalue';
+const { it, expect } = fixtures.defineTestFixtures<{ testInfoForward: TestInfo }>({
+  testInfoForward: async ({ testInfo }, runTest) => {
+    await runTest(testInfo);
+    testInfo.data['myname'] = 'myvalue';
+  },
 });
 
 it('ensure fixture handles test error', async ({ testInfoForward }) => {

--- a/test/assets/test-error-visible-in-fixture.ts
+++ b/test/assets/test-error-visible-in-fixture.ts
@@ -14,15 +14,13 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
-import * as path from 'path';
 import { fixtures } from '../../';
 
-const { it, expect, defineTestFixture } = fixtures.declareTestFixtures<{ postProcess: string }>();
-
-defineTestFixture('postProcess', async ({testInfo}, runTest) => {
-  await runTest('');
-  console.log('ERROR[[[' + JSON.stringify(testInfo.error, undefined, 2) + ']]]');
+const { it, expect } = fixtures.defineTestFixtures<{ postProcess: string }>({
+  postProcess: async ({testInfo}, runTest) => {
+    await runTest('');
+    console.log('ERROR[[[' + JSON.stringify(testInfo.error, undefined, 2) + ']]]');
+  },
 });
 
 it('ensure fixture handles test error', async ({ postProcess }) => {

--- a/test/fixture-errors.spec.ts
+++ b/test/fixture-errors.spec.ts
@@ -20,11 +20,11 @@ const { it, expect } = fixtures;
 it('should handle fixture timeout', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const { it, defineTestFixture } = baseFixtures;
-
-      defineTestFixture('timeout', async ({}, runTest) => {
-        await runTest();
-        await new Promise(f => setTimeout(f, 100000));
+      const { it } = baseFixtures.defineTestFixtures({
+        timeout: async ({}, runTest) => {
+          await runTest();
+          await new Promise(f => setTimeout(f, 100000));
+        },
       });
 
       it('fixture timeout', async ({timeout}) => {
@@ -44,9 +44,9 @@ it('should handle fixture timeout', async ({ runInlineFixturesTest }) => {
 it('should handle worker fixture timeout', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const { it, defineWorkerFixture } = baseFixtures;
-
-      defineWorkerFixture('timeout', async ({}, runTest) => {
+      const { it } = baseFixtures.defineWorkerFixtures({
+        timeout: async ({}, runTest) => {
+        },
       });
 
       it('fails', async ({timeout}) => {
@@ -60,10 +60,10 @@ it('should handle worker fixture timeout', async ({ runInlineFixturesTest }) => 
 it('should handle worker fixture error', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const { it, defineWorkerFixture } = baseFixtures;
-
-      defineWorkerFixture('failure', async ({}, runTest) => {
-        throw new Error('Worker failed');
+      const { it } = baseFixtures.defineWorkerFixtures({
+        failure: async ({}, runTest) => {
+          throw new Error('Worker failed');
+        },
       });
 
       it('fails', async ({failure}) => {
@@ -78,11 +78,11 @@ it('should handle worker fixture error', async ({ runInlineFixturesTest }) => {
 it('should handle worker tear down fixture error', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const { it, defineWorkerFixture } = baseFixtures;
-
-      defineWorkerFixture('failure', async ({}, runTest) => {
-        await runTest();
-        throw new Error('Worker failed');
+      const { it } = baseFixtures.defineWorkerFixtures({
+        failure: async ({}, runTest) => {
+          await runTest();
+          throw new Error('Worker failed');
+        },
       });
 
       it('pass', async ({failure}) => {
@@ -97,75 +97,81 @@ it('should handle worker tear down fixture error', async ({ runInlineFixturesTes
 it('should throw when overriding non-defined worker fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const { it, overrideWorkerFixture } = baseFixtures;
-      overrideWorkerFixture('foo', async ({}, runTest) => {
-        await runTest();
+      const { it } = baseFixtures.overrideWorkerFixtures({
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       it('works', async ({foo}) => {});
     `
   });
-  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has not been registered yet. Use defineWorkerFixture instead.');
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has not been registered yet. Use defineWorkerFixtures instead.');
   expect(result.exitCode).toBe(1);
 });
 
 it('should throw when defining worker fixture twice', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'b.spec.ts': `
-      const { it, defineWorkerFixture } = baseFixtures;
-      defineWorkerFixture('foo', async ({}, runTest) => {
-        await runTest();
+      const f1 = baseFixtures.defineWorkerFixtures({
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
-      defineWorkerFixture('foo', async ({}, runTest) => {
-        await runTest();
+      const { it } = f1.defineWorkerFixtures({
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       it('works', async ({foo}) => {});
     `
   });
-  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has already been registered. Use overrideWorkerFixture to override it in a specific test file.');
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has already been registered. Use overrideWorkerFixtures to override it in a specific test file.');
   expect(result.exitCode).toBe(1);
 });
 
 it('should throw when overriding non-defined test fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'c.spec.ts': `
-      const { it, overrideTestFixture } = baseFixtures;
-      overrideTestFixture('foo', async ({}, runTest) => {
-        await runTest();
+      const { it } = baseFixtures.overrideTestFixtures({
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       it('works', async ({foo}) => {});
     `
   });
-  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has not been registered yet. Use defineTestFixture instead.');
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has not been registered yet. Use defineTestFixtures instead.');
   expect(result.exitCode).toBe(1);
 });
 
 it('should throw when defining test fixture twice', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'd.spec.ts': `
-      const { it, defineTestFixture } = baseFixtures;
-      defineTestFixture('foo', async ({}, runTest) => {
-        await runTest();
+      const f1 = baseFixtures.defineTestFixtures({
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
-      defineTestFixture('foo', async ({}, runTest) => {
-        await runTest();
+      const { it } = f1.defineTestFixtures({
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       it('works', async ({foo}) => {});
     `
   });
-  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has already been registered. Use overrideTestFixture to override it in a specific test file.');
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" has already been registered. Use overrideTestFixtures to override it in a specific test file.');
   expect(result.exitCode).toBe(1);
 });
 
 it('should throw when defining test fixture with the same name as a worker fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'e.spec.ts': `
-      const { it, defineTestFixture, defineWorkerFixture } = baseFixtures;
-      defineWorkerFixture('foo', async ({}, runTest) => {
+      const { it } = baseFixtures.defineWorkerFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
-      defineTestFixture('foo', async ({}, runTest) => {
+      } }).defineTestFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
+      } });
       it('works', async ({foo}) => {});
     `,
   });
@@ -176,13 +182,11 @@ it('should throw when defining test fixture with the same name as a worker fixtu
 it('should throw when defining worker fixture with the same name as a test fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'e.spec.ts': `
-      const { it, defineTestFixture, defineWorkerFixture } = baseFixtures;
-      defineTestFixture('foo', async ({}, runTest) => {
+      const { it } = baseFixtures.defineTestFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
-      defineWorkerFixture('foo', async ({}, runTest) => {
+      } }).defineWorkerFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
+      } });
       it('works', async ({foo}) => {});
     `,
   });
@@ -193,48 +197,42 @@ it('should throw when defining worker fixture with the same name as a test fixtu
 it('should throw when overriding worker fixture as a test fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'f.spec.ts': `
-      const { it, overrideTestFixture, defineWorkerFixture } = baseFixtures;
-      defineWorkerFixture('foo', async ({}, runTest) => {
+      const { it } = baseFixtures.defineWorkerFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
-      overrideTestFixture('foo', async ({}, runTest) => {
+      } }).overrideTestFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
+      } });
       it('works', async ({foo}) => {});
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Fixture "foo" is a worker fixture. Use overrideWorkerFixture instead.');
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" is a worker fixture. Use overrideWorkerFixtures instead.');
   expect(result.exitCode).toBe(1);
 });
 
 it('should throw when overriding test fixture as a worker fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'f.spec.ts': `
-      const { it, overrideWorkerFixture, defineTestFixture } = baseFixtures;
-      defineTestFixture('foo', async ({}, runTest) => {
+      const { it } = baseFixtures.defineTestFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
-      overrideWorkerFixture('foo', async ({}, runTest) => {
+      } }).overrideWorkerFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
+      } });
       it('works', async ({foo}) => {});
     `,
   });
-  expect(result.report.errors[0].error.message).toContain('Fixture "foo" is a test fixture. Use overrideTestFixture instead.');
-  expect(result.report.errors[0].error.stack).toContain('f.spec.ts:8');
+  expect(result.report.errors[0].error.message).toContain('Fixture "foo" is a test fixture. Use overrideTestFixtures instead.');
+  expect(result.report.errors[0].error.stack).toContain('f.spec.ts:6');
   expect(result.exitCode).toBe(1);
 });
 
 it('should throw when worker fixture depends on a test fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'f.spec.ts': `
-      const { it, defineWorkerFixture, defineTestFixture } = baseFixtures;
-      defineTestFixture('foo', async ({}, runTest) => {
+      const { it } = baseFixtures.defineTestFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
-      defineWorkerFixture('bar', async ({foo}, runTest) => {
+      } }).defineWorkerFixtures({ bar: async ({foo}, runTest) => {
         await runTest();
-      });
+      } });
       it('works', async ({bar}) => {});
     `,
   });
@@ -245,23 +243,19 @@ it('should throw when worker fixture depends on a test fixture', async ({ runInl
 it('should define and override the same fixture in two files', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const { it, defineWorkerFixture, overrideWorkerFixture } = baseFixtures;
-      defineWorkerFixture('foo', async ({}, runTest) => {
+      const { it } = baseFixtures.defineWorkerFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
-      overrideWorkerFixture('foo', async ({}, runTest) => {
+      } }).overrideWorkerFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
+      } });
       it('works', async ({foo}) => {});
     `,
     'b.spec.ts': `
-      const { it, defineWorkerFixture, overrideWorkerFixture } = baseFixtures;
-      defineWorkerFixture('foo', async ({}, runTest) => {
+      const { it } = baseFixtures.defineWorkerFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
-      overrideWorkerFixture('foo', async ({}, runTest) => {
+      } }).overrideWorkerFixtures({ foo: async ({}, runTest) => {
         await runTest();
-      });
+      } });
       it('works', async ({foo}) => {});
     `,
   });
@@ -272,24 +266,25 @@ it('should define and override the same fixture in two files', async ({ runInlin
 it('should detect fixture dependency cycle', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'x.spec.ts': `
-      const { it, defineTestFixture } = baseFixtures;
-      defineTestFixture('good1', async ({}, runTest) => {
-        await runTest();
-      });
-      defineTestFixture('foo', async ({bar}, runTest) => {
-        await runTest();
-      });
-      defineTestFixture('bar', async ({baz}, runTest) => {
-        await runTest();
-      });
-      defineTestFixture('good2', async ({good1}, runTest) => {
-        await runTest();
-      });
-      defineTestFixture('baz', async ({qux}, runTest) => {
-        await runTest();
-      });
-      defineTestFixture('qux', async ({foo}, runTest) => {
-        await runTest();
+      const { it } = baseFixtures.defineTestFixtures({
+        good1: async ({}, runTest) => {
+          await runTest();
+        },
+        foo: async ({bar}, runTest) => {
+          await runTest();
+        },
+        bar: async ({baz}, runTest) => {
+          await runTest();
+        },
+        good2: async ({good1}, runTest) => {
+          await runTest();
+        },
+        baz: async ({qux}, runTest) => {
+          await runTest();
+        },
+        qux: async ({foo}, runTest) => {
+          await runTest();
+        }
       });
       it('works', async ({foo}) => {});
     `,

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -17,10 +17,12 @@ import { expect } from '@playwright/test-runner';
 import { fixtures } from './fixtures';
 const { it } = fixtures;
 
-it('should work', async ({ runInlineTest }) => {
-  const { results } = await runInlineTest({
+it('should work', async ({ runInlineFixturesTest }) => {
+  const { results } = await runInlineFixturesTest({
     'a.test.js': `
-      fixtures.defineTestFixture('asdf', async ({}, test) => await test(123));
+      const { it } = baseFixtures.defineTestFixtures({
+        asdf: async ({}, test) => await test(123)
+      });
       it('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(123);
       });
@@ -29,10 +31,12 @@ it('should work', async ({ runInlineTest }) => {
   expect(results[0].status).toBe('passed');
 });
 
-it('should work with a sync function', async ({ runInlineTest }) => {
-  const { results } = await runInlineTest({
+it('should work with a sync function', async ({ runInlineFixturesTest }) => {
+  const { results } = await runInlineFixturesTest({
     'a.test.js': `
-      fixtures.defineTestFixture('asdf', async ({}, test) => await test(123));
+      const { it } = baseFixtures.defineTestFixtures({
+        asdf: async ({}, test) => await test(123)
+      });
       it('should use asdf', ({asdf}) => {
         expect(asdf).toBe(123);
       });
@@ -41,10 +45,12 @@ it('should work with a sync function', async ({ runInlineTest }) => {
   expect(results[0].status).toBe('passed');
 });
 
-it('should work with a non-arrow function', async ({ runInlineTest }) => {
-  const { results } = await runInlineTest({
+it('should work with a non-arrow function', async ({ runInlineFixturesTest }) => {
+  const { results } = await runInlineFixturesTest({
     'a.test.js': `
-      fixtures.defineTestFixture('asdf', async ({}, test) => await test(123));
+      const { it } = baseFixtures.defineTestFixtures({
+        asdf: async ({}, test) => await test(123)
+      });
       it('should use asdf', function ({asdf}) {
         expect(asdf).toBe(123);
       });
@@ -53,10 +59,12 @@ it('should work with a non-arrow function', async ({ runInlineTest }) => {
   expect(results[0].status).toBe('passed');
 });
 
-it('should work with a named function', async ({ runInlineTest }) => {
-  const { results } = await runInlineTest({
+it('should work with a named function', async ({ runInlineFixturesTest }) => {
+  const { results } = await runInlineFixturesTest({
     'a.test.js': `
-      fixtures.defineTestFixture('asdf', async ({}, test) => await test(123));
+      const { it } = baseFixtures.defineTestFixtures({
+        asdf: async ({}, test) => await test(123)
+      });
       it('should use asdf', async function hello({asdf}) {
         expect(asdf).toBe(123);
       });
@@ -65,10 +73,12 @@ it('should work with a named function', async ({ runInlineTest }) => {
   expect(results[0].status).toBe('passed');
 });
 
-it('should work with renamed parameters', async ({ runInlineTest }) => {
-  const { results } = await runInlineTest({
+it('should work with renamed parameters', async ({ runInlineFixturesTest }) => {
+  const { results } = await runInlineFixturesTest({
     'a.test.js': `
-      fixtures.defineTestFixture('asdf', async ({}, test) => await test(123));
+      const { it } = baseFixtures.defineTestFixtures({
+        asdf: async ({}, test) => await test(123)
+      });
       it('should use asdf', function ({asdf: renamed}) {
         expect(renamed).toBe(123);
       });
@@ -77,10 +87,12 @@ it('should work with renamed parameters', async ({ runInlineTest }) => {
   expect(results[0].status).toBe('passed');
 });
 
-it('should fail if parameters are not destructured', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
+it('should fail if parameters are not destructured', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
     'a.test.js': `
-      fixtures.defineTestFixture('asdf', async ({}, test) => await test(123));
+      const { it } = baseFixtures.defineTestFixtures({
+        asdf: async ({}, test) => await test(123)
+      });
       it('should pass', function () {
         expect(1).toBe(1);
       });
@@ -107,11 +119,13 @@ it('should fail with an unknown fixture', async ({ runInlineTest }) => {
   expect(results[0].error.message).toBe('Unknown fixture: asdf');
 });
 
-it('should run the fixture every time', async ({ runInlineTest }) => {
-  const { results } = await runInlineTest({
+it('should run the fixture every time', async ({ runInlineFixturesTest }) => {
+  const { results } = await runInlineFixturesTest({
     'a.test.js': `
       let counter = 0;
-      fixtures.defineTestFixture('asdf', async ({}, test) => await test(counter++));
+      const { it } = baseFixtures.defineTestFixtures({
+        asdf: async ({}, test) => await test(counter++)
+      });
       it('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(0);
       });
@@ -126,11 +140,13 @@ it('should run the fixture every time', async ({ runInlineTest }) => {
   expect(results.map(r => r.status)).toEqual(['passed', 'passed', 'passed']);
 });
 
-it('should only run worker fixtures once', async ({ runInlineTest }) => {
-  const { results } = await runInlineTest({
+it('should only run worker fixtures once', async ({ runInlineFixturesTest }) => {
+  const { results } = await runInlineFixturesTest({
     'a.test.js': `
       let counter = 0;
-      fixtures.defineWorkerFixture('asdf', async ({}, test) => await test(counter++));
+      const { it } = baseFixtures.defineWorkerFixtures({
+        asdf: async ({}, test) => await test(counter++)
+      });
       it('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(0);
       });
@@ -145,27 +161,36 @@ it('should only run worker fixtures once', async ({ runInlineTest }) => {
   expect(results.map(r => r.status)).toEqual(['passed', 'passed', 'passed']);
 });
 
-it('each file should get their own fixtures', async ({ runInlineTest }) => {
-  const { results } = await runInlineTest({
+it('each file should get their own fixtures', async ({ runInlineFixturesTest }) => {
+  const { results } = await runInlineFixturesTest({
     'a.test.js': `
-      fixtures.defineWorkerFixture('worker', async ({}, test) => await test('worker-a'));
-      fixtures.defineTestFixture('test', async ({}, test) => await test('test-a'));
+      const { it } = baseFixtures.defineWorkerFixtures({
+        worker: async ({}, test) => await test('worker-a'),
+      }).defineTestFixtures({
+        test: async ({}, test) => await test('test-a'),
+      });
       it('should use worker', async ({worker, test}) => {
         expect(worker).toBe('worker-a');
         expect(test).toBe('test-a');
       });
     `,
     'b.test.js': `
-      fixtures.defineWorkerFixture('worker', async ({}, test) => await test('worker-b'));
-      fixtures.defineTestFixture('test', async ({}, test) => await test('test-b'));
+      const { it } = baseFixtures.defineWorkerFixtures({
+        worker: async ({}, test) => await test('worker-b'),
+      }).defineTestFixtures({
+        test: async ({}, test) => await test('test-b'),
+      });
       it('should use worker', async ({worker, test}) => {
         expect(worker).toBe('worker-b');
         expect(test).toBe('test-b');
       });
     `,
     'c.test.js': `
-      fixtures.defineWorkerFixture('worker', async ({}, test) => await test('worker-c'));
-      fixtures.defineTestFixture('test', async ({}, test) => await test('test-c'));
+      const { it } = baseFixtures.defineWorkerFixtures({
+        worker: async ({}, test) => await test('worker-c'),
+      }).defineTestFixtures({
+        test: async ({}, test) => await test('test-c'),
+      });
       it('should use worker', async ({worker, test}) => {
         expect(worker).toBe('worker-c');
         expect(test).toBe('test-c');
@@ -175,26 +200,28 @@ it('each file should get their own fixtures', async ({ runInlineTest }) => {
   expect(results.map(r => r.status)).toEqual(['passed', 'passed', 'passed']);
 });
 
-it('tests should be able to share worker fixtures', async ({ runInlineTest }) => {
-  const { results } = await runInlineTest({
+it('tests should be able to share worker fixtures', async ({ runInlineFixturesTest }) => {
+  const { results } = await runInlineFixturesTest({
     'worker.js': `
       global.counter = 0;
-      fixtures.defineWorkerFixture('worker', async ({}, test) => await test(global.counter++));
+      module.exports = baseFixtures.defineWorkerFixtures({
+        worker: async ({}, test) => await test(global.counter++)
+      });
     `,
     'a.test.js': `
-      require('./worker.js');
+      const { it } = require('./worker.js');
       it('should use worker', async ({worker}) => {
         expect(worker).toBe(0);
       });
     `,
     'b.test.js': `
-      require('./worker.js');
+      const { it } = require('./worker.js');
       it('should use worker', async ({worker}) => {
         expect(worker).toBe(0);
       });
     `,
     'c.test.js': `
-      require('./worker.js');
+      const { it } = require('./worker.js');
       it('should use worker', async ({worker}) => {
         expect(worker).toBe(0);
       });
@@ -203,14 +230,16 @@ it('tests should be able to share worker fixtures', async ({ runInlineTest }) =>
   expect(results.map(r => r.status)).toEqual(['passed', 'passed', 'passed']);
 });
 
-it('tests respect automatic test fixtures', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
+it('tests respect automatic test fixtures', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
     'a.test.js': `
       let counter = 0;
-      fixtures.defineTestFixture('automaticTestFixture', async ({}, runTest) => {
-        ++counter;
-        await runTest();
-      }, { auto: true  });
+      const { it } = baseFixtures.defineTestFixtures({
+        automaticTestFixture: async ({}, runTest) => {
+          ++counter;
+          await runTest();
+        },
+      });
       it('test 1', async ({}) => {
         expect(counter).toBe(1);
       });
@@ -223,14 +252,16 @@ it('tests respect automatic test fixtures', async ({ runInlineTest }) => {
   expect(result.results.map(r => r.status)).toEqual(['passed', 'passed']);
 });
 
-it('tests respect automatic worker fixtures', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
+it('tests respect automatic worker fixtures', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
     'a.test.js': `
       let counter = 0;
-      fixtures.defineWorkerFixture('automaticWorkerFixture', async ({}, runTest) => {
-        ++counter;
-        await runTest();
-      }, { auto: true  });
+      const { it } = baseFixtures.defineWorkerFixtures({
+        automaticWorkerFixture: async ({}, runTest) => {
+          ++counter;
+          await runTest();
+        },
+      });
       it('test 1', async ({}) => {
         expect(counter).toBe(1);
       });
@@ -243,14 +274,16 @@ it('tests respect automatic worker fixtures', async ({ runInlineTest }) => {
   expect(result.results.map(r => r.status)).toEqual(['passed', 'passed']);
 });
 
-it('tests does not run non-automatic worker fixtures', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
+it('tests does not run non-automatic worker fixtures', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
     'a.test.js': `
       let counter = 0;
-      fixtures.defineWorkerFixture('nonAutomaticWorkerFixture', async ({}, runTest) => {
-        ++counter;
-        await runTest();
-      }, { auto: false  });
+      const { it } = baseFixtures.defineTestFixtures({
+        nonAutomaticWorkerFixture: async ({}, runTest) => {
+          ++counter;
+          await runTest();
+        },
+      });
       it('test 1', async ({}) => {
         expect(counter).toBe(0);
       });
@@ -263,9 +296,10 @@ it('tests does not run non-automatic worker fixtures', async ({ runInlineTest })
 it('should not reuse fixtures from one file in another one', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const { it, defineTestFixture } = baseFixtures;
-      defineTestFixture('foo', async ({}, runTest) => {
-        await runTest();
+      const { it } = baseFixtures.defineTestFixtures({
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       it('test1', async ({}) => {});
     `,

--- a/test/list-mode.spec.ts
+++ b/test/list-mode.spec.ts
@@ -17,14 +17,15 @@ import { expect } from '@playwright/test-runner';
 import { fixtures } from './fixtures';
 const { it } = fixtures;
 
-it('should work with parameters', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
-    'fixture.spec.js': `
-      fixtures.defineParameter('worker', '', '');
+it('should work with parameters', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'fixtures.js': `
+      const fixtures = baseFixtures.defineParameter('worker', '', '');
       fixtures.generateParametrizedTests('worker', ['A', 'B', 'C']);
+      module.exports = fixtures;
     `,
     'a.test.js': `
-      require('./fixture.spec.js');
+      const { it } = require('./fixtures.js');
       it('should use worker A', (test, parameters) => {
         test.fail(parameters.worker !== 'A');
       }, async ({worker}) => {
@@ -32,7 +33,7 @@ it('should work with parameters', async ({ runInlineTest }) => {
       });
     `,
     'b.test.js': `
-      require('./fixture.spec.js');
+      const { it } = require('./fixtures.js');
       it('should use worker B', (test, parameters) => {
         test.fail(parameters.worker !== 'B');
       }, async ({worker}) => {
@@ -40,7 +41,7 @@ it('should work with parameters', async ({ runInlineTest }) => {
       });
     `,
     'c.test.js': `
-      require('./fixture.spec.js');
+      const { it } = require('./fixtures.js');
       it('should use worker C', (test, parameters) => {
         test.fail(parameters.worker !== 'C');
       }, async ({worker}) => {

--- a/test/override-fixtures.spec.ts
+++ b/test/override-fixtures.spec.ts
@@ -17,47 +17,56 @@
 import { fixtures } from './fixtures';
 const { it, expect } = fixtures;
 
-it('should respect require order', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
+it('should respect require order', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
     'fixture.js': `
-      fixtures.defineWorkerFixture('fixture', ({}, runTest) => runTest('base'));
+      exports.fixtures = baseFixtures.defineWorkerFixtures({
+        fixture: ({}, runTest) => runTest('base')
+      });
     `,
     'override1.js': `
-      require('./fixture.js');
-      fixtures.overrideWorkerFixture('fixture', ({}, runTest) => runTest('override1'));
+      exports.fixtures = require('./fixture.js').fixtures.overrideWorkerFixtures({
+        fixture: ({}, runTest) => runTest('override1')
+      });
     `,
     'override2.js': `
-      require('./fixture.js');
-      fixtures.overrideWorkerFixture('fixture', ({}, runTest) => runTest('override2'));
+      exports.fixtures = require('./fixture.js').fixtures.overrideWorkerFixtures({
+        fixture: ({}, runTest) => runTest('override2')
+      });
     `,
     'a.test.js': `
-      require('./fixture.js');
+      const { fixtures } = require('./fixture.js');
+      const { it } = fixtures;
       it('should pass', ({fixture}) => {
         expect(fixture).toBe('base');
       })
     `,
     'b.test.js': `
-      require('./override1.js');
+      const { fixtures } = require('./override1.js');
+      const { it } = fixtures;
       it('should pass', ({fixture}) => {
         expect(fixture).toBe('override1');
       })
     `,
     'c.test.js': `
-      require('./override2.js');
+      const { fixtures } = require('./override2.js');
+      const { it } = fixtures;
       it('should pass', ({fixture}) => {
         expect(fixture).toBe('override2');
       })
     `,
     'd.test.js': `
       require('./override1.js');
-      require('./override2.js');
+      const { fixtures } = require('./override2.js');
+      const { it } = fixtures;
       it('should pass', ({fixture}) => {
         expect(fixture).toBe('override2');
       })
     `,
     'e.test.js': `
       require('./override2.js');
-      require('./override1.js');
+      const { fixtures } = require('./override1.js');
+      const { it } = fixtures;
       it('should pass', ({fixture}) => {
         expect(fixture).toBe('override1');
       })

--- a/test/parameters.spec.ts
+++ b/test/parameters.spec.ts
@@ -20,9 +20,9 @@ const { it, expect } = fixtures;
 it('should run with each configuration', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
-      const fixtures = baseFixtures.declareParameters<{ foo: string, bar: string }>();
-      fixtures.defineParameter('foo', 'Foo parameters', 'foo');
-      fixtures.defineParameter('bar', 'Bar parameters', 'bar');
+      const fixtures = baseFixtures
+        .defineParameter('foo', 'Foo parameters', 'foo')
+        .defineParameter('bar', 'Bar parameters', 'bar');
       fixtures.generateParametrizedTests('foo', ['foo1', 'foo2', 'foo3']);
       fixtures.generateParametrizedTests('bar', ['bar1', 'bar2']);
 
@@ -67,8 +67,7 @@ it('should fail on invalid parameters', async ({ runInlineTest }) => {
 it('should use kebab for CLI name', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
-      const fixtures = baseFixtures.declareParameters<{ fooCamelCase: string }>();
-      fixtures.defineParameter('fooCamelCase', 'Foo parameters', 'foo');
+      const fixtures = baseFixtures.defineParameter('fooCamelCase', 'Foo parameters', 'foo');
 
       const { it } = fixtures;
 
@@ -83,8 +82,7 @@ it('should use kebab for CLI name', async ({ runInlineFixturesTest }) => {
 it('should respect boolean CLI option', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
-      const fixtures = baseFixtures.declareParameters<{ fooCamelCase: boolean }>();
-      fixtures.defineParameter('fooCamelCase', 'Foo parameters', false);
+      const fixtures = baseFixtures.defineParameter('fooCamelCase', 'Foo parameters', false);
       const { it } = fixtures;
       it('test', async ({ fooCamelCase }) => {
         expect(fooCamelCase).toBeTruthy();
@@ -97,9 +95,9 @@ it('should respect boolean CLI option', async ({ runInlineFixturesTest }) => {
 it('should show parameters descriptions', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
-      const fixtures = baseFixtures.declareParameters<{ browserName: string, headful: boolean }>();
-      fixtures.defineParameter('browserName', 'Browser name', 'chromium');
-      fixtures.defineParameter('headful', 'Whether to show browser window or not', false);
+      const fixtures = baseFixtures
+          .defineParameter('browserName', 'Browser name', 'chromium')
+          .defineParameter('headful', 'Whether to show browser window or not', false);
     `
   }, { 'help': true });
   expect(result.output).toContain(`-p, --param browserName=<value>`);
@@ -113,8 +111,7 @@ it('should show parameters descriptions', async ({ runInlineFixturesTest }) => {
 it('should support integer parameter', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
-      const fixtures = baseFixtures.declareParameters<{ integer: number }>();
-      fixtures.defineParameter('integer', 'Some integer', 5);
+      const fixtures = baseFixtures.defineParameter('integer', 'Some integer', 5);
       const { it } = fixtures;
       it('success', async ({integer}) => {
         expect(integer).toBe(6);
@@ -127,8 +124,7 @@ it('should support integer parameter', async ({ runInlineFixturesTest }) => {
 it('should support boolean parameter', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
-      const fixtures = baseFixtures.declareParameters<{ bool: boolean }>();
-      fixtures.defineParameter('bool', 'Some bool', false);
+      const fixtures = baseFixtures.defineParameter('bool', 'Some bool', false);
       const { it } = fixtures;
       it('success', async ({bool}) => {
         expect(bool).toBe(true);
@@ -141,8 +137,7 @@ it('should support boolean parameter', async ({ runInlineFixturesTest }) => {
 it('should generate tests from CLI', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `
-      const fixtures = baseFixtures.declareParameters<{ bool: boolean }>();
-      fixtures.defineParameter('bool', 'Some bool', false);
+      const fixtures = baseFixtures.defineParameter('bool', 'Some bool', false);
       const { it } = fixtures;
       it('success', async ({bool}) => {
         expect(bool).toBe(true);
@@ -155,13 +150,14 @@ it('should generate tests from CLI', async ({ runInlineFixturesTest }) => {
   expect(result.failed).toBe(1);
 });
 
-it('tests respect automatic fixture parameters', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
+it('tests respect automatic fixture parameters', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
     'a.test.js': `
-      fixtures.defineParameter('param', 'Some param', 'value');
-      fixtures.defineTestFixture('automaticTestFixture', async ({param}, runTest) => {
-        await runTest(param);
-      }, { auto: true  });
+      const { it } = baseFixtures
+        .defineParameter('param', 'Some param', 'value')
+        .defineTestFixtures({ automaticTestFixture: async ({param}, runTest) => {
+          await runTest(param);
+        } });
       it('test 1', async ({}) => {
         expect(1).toBe(1);
       });

--- a/test/stdio.spec.ts
+++ b/test/stdio.spec.ts
@@ -40,12 +40,11 @@ it('should get top level stdio', async ({runInlineTest}) => {
 it('should get stdio from worker fixture teardown', async ({runInlineFixturesTest}) => {
   const result = await runInlineFixturesTest({
     'a.spec.js': `
-      const { it, defineWorkerFixture } = baseFixtures;
-      defineWorkerFixture('fixture', async ({}, runTest) => {
+      const { it } = baseFixtures.defineWorkerFixtures({ fixture: async ({}, runTest) => {
         console.log('\\n%% worker setup');
         await runTest();
         console.log('\\n%% worker teardown');
-      });
+      } });
       it('is a test', async ({fixture}) => {});
     `
   });

--- a/test/test-info-fixture.spec.ts
+++ b/test/test-info-fixture.spec.ts
@@ -31,10 +31,12 @@ it('should work directly', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
 });
 
-it('should work via fixture', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
+it('should work via fixture', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
     'a.test.js': `
-      fixtures.defineTestFixture('title', async ({testInfo}, test) => await test(testInfo.title));
+      const { it } = baseFixtures.defineTestFixtures({
+        title: async ({testInfo}, test) => await test(testInfo.title)
+      });
       it('test 1', async ({title}) => {
         expect(title).toBe('test 1');
       });

--- a/test/worker-index.spec.ts
+++ b/test/worker-index.spec.ts
@@ -46,12 +46,13 @@ it('should run in parallel', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
 });
 
-it('should reuse worker for the same parameters', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
+it('should reuse worker for the same parameters', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
     'a.test.js': `
-      const { defineWorkerFixture } = fixtures;
-      defineWorkerFixture('worker1', ({}, runTest) => runTest());
-      defineWorkerFixture('worker2', ({}, runTest) => runTest());
+      const { it } = baseFixtures.defineWorkerFixtures({
+        worker1: ({}, runTest) => runTest(),
+        worker2: ({}, runTest) => runTest(),
+      });
 
       it('succeeds', async ({ worker1, testWorkerIndex }) => {
         expect(testWorkerIndex).toBe(0);
@@ -66,10 +67,10 @@ it('should reuse worker for the same parameters', async ({ runInlineTest }) => {
   expect(result.exitCode).toBe(0);
 });
 
-it('should not reuse worker for different parameters', async ({ runInlineTest }) => {
-  const result = await runInlineTest({
+it('should not reuse worker for different parameters', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
     'a.test.js': `
-      fixtures.defineParameter('param', '', '');
+      const { it } = baseFixtures.defineParameter('param', '', '');
 
       it('succeeds', async ({ testWorkerIndex }) => {
         expect(testWorkerIndex).toBe(0);


### PR DESCRIPTION
Changes declare+define to just a define with an object,
but forces to use the resulting instance instead of piling up
on previous fixtures. Also, turns all fixtures that start with
`auto` into auto-instantiated fixtures. See tests for examples.

This should not be too bad for typescript fixture definitions,
except for forcing chaining (or intermediate variable) when
defining both worker and test fixtures:

```ts
const fixtures = baseFixtures.defineWorkerFixtures<{ w: string }>({
  w: async () => {},
}).defineTestFixtures<{ t: string }>({
  t: async () => {},
});
```

This should allow us to avoid any issues with multiple tests
defining their fixtures differently, because we can use separate
Fixtures class instance, returned from `defineFooFixtures` call.
This new instance is not implemented yet.