### PR TITLE
feat: implement new fixtures chaining

### DIFF
--- a/src/expect.ts
+++ b/src/expect.ts
@@ -16,7 +16,7 @@
 
 import type { Expect } from './expectType';
 import expectLibrary from 'expect';
-import { config, currentTestInfo } from '.';
+import { config, currentTestInfo } from './fixtures';
 import { compare } from './golden';
 
 export const expect: Expect = expectLibrary;

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,105 +15,12 @@
  * limitations under the License.
  */
 
-import { expect } from './expect';
 export { expect } from './expect';
-import { config, registerFixture, registerWorkerFixture, registerWorkerParameter, setParameterValues, TestInfo } from './fixtures';
-import { compare } from './golden';
-import * as spec from './spec';
-import { TestModifier } from './testModifier';
+import { TestInfo } from './fixtures';
+import { rootFixtures } from './spec';
+export { Fixtures } from './spec';
 export { Config } from './config';
 export { config, TestInfo, currentTestInfo } from './fixtures';
-import prettyFormat from 'pretty-format';
-
-interface DescribeHelper<WorkerParameters> {
-  describe(name: string, inner: () => void): void;
-  describe(name: string, modifierFn: (modifier: TestModifier, parameters: WorkerParameters) => any, inner: () => void): void;
-}
-type DescribeFunction<WorkerParameters> = DescribeHelper<WorkerParameters>['describe'];
-interface ItHelper<WorkerParameters, WorkerFixtures, TestFixtures> {
-  it(name: string, inner: (fixtures: WorkerParameters & WorkerFixtures & TestFixtures) => Promise<void> | void): void;
-  it(name: string, modifierFn: (modifier: TestModifier, parameters: WorkerParameters) => any, inner: (fixtures: WorkerParameters & WorkerFixtures & TestFixtures) => Promise<void> | void): void;
-}
-type ItFunction<WorkerParameters, WorkerFixtures, TestFixtures> = ItHelper<WorkerParameters, WorkerFixtures, TestFixtures>['it'];
-type It<WorkerParameters, WorkerFixtures, TestFixtures> = ItFunction<WorkerParameters, WorkerFixtures, TestFixtures> & {
-  only: ItFunction<WorkerParameters, WorkerFixtures, TestFixtures>;
-  skip: ItFunction<WorkerParameters, WorkerFixtures, TestFixtures>;
-};
-type Fit<WorkerParameters, WorkerFixtures, TestFixtures> = ItFunction<WorkerParameters, WorkerFixtures, TestFixtures>;
-type Xit<WorkerParameters, WorkerFixtures, TestFixtures> = ItFunction<WorkerParameters, WorkerFixtures, TestFixtures>;
-type Describe<WorkerParameters> = DescribeFunction<WorkerParameters> & {
-  only: DescribeFunction<WorkerParameters>;
-  skip: DescribeFunction<WorkerParameters>;
-};
-type FDescribe<WorkerParameters> = DescribeFunction<WorkerParameters>;
-type XDescribe<WorkerParameters> = DescribeFunction<WorkerParameters>;
-type BeforeEach<WorkerParameters, WorkerFixtures, TestFixtures> = (inner: (fixtures: WorkerParameters & WorkerFixtures & TestFixtures) => Promise<void>) => void;
-type AfterEach<WorkerParameters, WorkerFixtures, TestFixtures> = (inner: (fixtures: WorkerParameters & WorkerFixtures & TestFixtures) => Promise<void>) => void;
-type BeforeAll<WorkerFixtures> = (inner: (fixtures: WorkerFixtures) => Promise<void>) => void;
-type AfterAll<WorkerFixtures> = (inner: (fixtures: WorkerFixtures) => Promise<void>) => void;
-
-class FixturesImpl<WorkerParameters, WorkerFixtures, TestFixtures> {
-  it: It<WorkerParameters, WorkerFixtures, TestFixtures> = spec.it;
-  fit: Fit<WorkerParameters, WorkerFixtures, TestFixtures> = spec.it.only;
-  xit: Xit<WorkerParameters, WorkerFixtures, TestFixtures> = spec.it.skip;
-  test: It<WorkerParameters, WorkerFixtures, TestFixtures> = spec.it;
-  describe: Describe<WorkerParameters> = spec.describe;
-  fdescribe: FDescribe<WorkerParameters> = spec.describe.only;
-  xdescribe: XDescribe<WorkerParameters> = spec.describe.skip;
-  beforeEach: BeforeEach<WorkerParameters, WorkerFixtures, TestFixtures> = spec.beforeEach;
-  afterEach: AfterEach<WorkerParameters, WorkerFixtures, TestFixtures> = spec.afterEach;
-  beforeAll: BeforeAll<WorkerFixtures> = spec.beforeAll;
-  afterAll: AfterAll<WorkerFixtures> = spec.afterAll;
-  expect: typeof expect = expect;
-
-  union<P1, W1, T1>(other1: Fixtures<P1, W1, T1>): Fixtures<WorkerParameters & P1, WorkerFixtures & W1, TestFixtures & T1>;
-  union<P1, W1, T1, P2, W2, T2>(other1: Fixtures<P1, W1, T1>, other2: Fixtures<P2, W2, T2>): Fixtures<WorkerParameters & P1 & P2, WorkerFixtures & W1 & W2, TestFixtures & T1 & T2>;
-  union<P1, W1, T1, P2, W2, T2, P3, W3, T3>(other1: Fixtures<P1, W1, T1>, other2: Fixtures<P2, W2, T2>, other3: Fixtures<P3, W3, T3>): Fixtures<WorkerParameters & P1 & P2 & P3, WorkerFixtures & W1 & W2 & W3, TestFixtures & T1 & T2 & T3>;
-  union(...others) {
-    return this;
-  }
-
-  defineTestFixtures<T extends object>(o: { [ key in keyof T]: (params: WorkerParameters & WorkerFixtures & TestFixtures & T, runTest: (value: T[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures & T> {
-    for (const [ name, fixture ] of Object.entries(o))
-      registerFixture(name, fixture as any, { auto: name.startsWith('auto') }, false);
-    return this as any;
-  }
-
-  overrideTestFixtures(o: { [ key in keyof TestFixtures ]?: (params: WorkerParameters & WorkerFixtures & TestFixtures, runTest: (value: TestFixtures[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures> {
-    for (const [ name, fixture ] of Object.entries(o))
-      registerFixture(name, fixture as any, { auto: name.startsWith('auto') }, true);
-    return this;
-  }
-
-  defineWorkerFixtures<T extends object>(o: { [ key in keyof T]: (params: WorkerParameters & WorkerFixtures & T, runTest: (value: T[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures & T, TestFixtures> {
-    for (const [ name, fixture ] of Object.entries(o))
-      registerWorkerFixture(name, fixture as any, { auto: name.startsWith('auto') }, false);
-    return this as any;
-  }
-
-  overrideWorkerFixtures(o: { [ key in keyof WorkerFixtures ]?: (params: WorkerParameters & WorkerFixtures, runTest: (value: WorkerFixtures[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures> {
-    for (const [ name, fixture ] of Object.entries(o))
-      registerWorkerFixture(name, fixture as any, { auto: name.startsWith('auto') }, true);
-    return this;
-  }
-
-  defineParameter<N extends string, P>(name: N, description: string, defaultValue: P): Fixtures<WorkerParameters & { [key in N] : P }, WorkerFixtures, TestFixtures> {
-    registerWorkerParameter({
-      name: name as string,
-      description,
-      defaultValue: defaultValue as any,
-    });
-    registerWorkerFixture(name as string, async ({}, runTest) => runTest(defaultValue), {}, false);
-    return this as any;
-  }
-
-  generateParametrizedTests<T extends keyof WorkerParameters>(name: T, values: WorkerParameters[T][]) {
-    setParameterValues(name as string, values);
-  }
-}
-
-export interface Fixtures<P, W, T> extends FixturesImpl<P, W, T> {
-}
 
 type BuiltinWorkerFixtures = {
   // Worker index that runs this test.
@@ -127,7 +34,7 @@ type BuiltinTestFixtures = {
   testParametersPathSegment: string;
 };
 
-export const fixtures = new FixturesImpl<{}, {}, {}>().defineWorkerFixtures<BuiltinWorkerFixtures>({
+export const fixtures = rootFixtures.defineWorkerFixtures<BuiltinWorkerFixtures>({
   testWorkerIndex: async ({}, runTest) => {
     // Worker injects the value for this one.
     await runTest(undefined as any);

--- a/src/runnerSpec.ts
+++ b/src/runnerSpec.ts
@@ -14,24 +14,23 @@
  * limitations under the License.
  */
 
-import * as fs from 'fs';
 import { installTransform } from './transform';
 import { RunnerSuite, RunnerSpec } from './runnerTest';
-import { callerFile, extractLocation } from './util';
-import { setImplementation } from './spec';
+import { extractLocation } from './util';
+import { FixturesImpl, setImplementation } from './spec';
 import { TestModifier } from './testModifier';
 
-export function runnerSpec(suite: RunnerSuite, timeout: number, file: string): () => void {
-  const resolvedFile = fs.realpathSync(file);
+export function runnerSpec(suite: RunnerSuite, timeout: number): () => void {
   const suites = [suite];
 
-  const it = (spec: 'default' | 'skip' | 'only', title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
+  const it = (spec: 'default' | 'skip' | 'only', fixtures: FixturesImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
     const suite = suites[0];
     if (typeof fn !== 'function') {
       fn = modifierFn;
       modifierFn = null;
     }
-    const test = new RunnerSpec(title, fn, suite);
+    const test = new RunnerSpec(fixtures, title, fn, suite);
+    test._usedParameters = fixtures._pool.parametersForFunction(fn, `Test`, true);
     test.file = suite.file;
     test.location = extractLocation(new Error());
     if (spec === 'only')
@@ -48,12 +47,12 @@ export function runnerSpec(suite: RunnerSuite, timeout: number, file: string): (
     return test;
   };
 
-  const describe = (spec: 'describe' | 'skip' | 'only', title: string, modifierFn: (suite: TestModifier, parameters: any) => void | Function, fn?: Function) => {
+  const describe = (spec: 'default' | 'skip' | 'only', fixtures: FixturesImpl, title: string, modifierFn: (suite: TestModifier, parameters: any) => void | Function, fn?: Function) => {
     if (typeof fn !== 'function') {
       fn = modifierFn;
       modifierFn = null;
     }
-    const child = new RunnerSuite(title, suites[0]);
+    const child = new RunnerSuite(fixtures, title, suites[0]);
     child.file = suite.file;
     child.location = extractLocation(new Error());
     if (spec === 'only')
@@ -73,27 +72,22 @@ export function runnerSpec(suite: RunnerSuite, timeout: number, file: string): (
     suites.shift();
   };
 
-  const hook = (hookName: string, fn: Function) => {
-    const hookFile = callerFile(hook, 3);
-    if (hookFile !== resolvedFile) {
-      throw new Error(`${hookName} hook should be called from the test file.\n` +
-          `Do you need a shared hook for multiple test files?\n` +
-          `  - Use {auto: true} option in defineWorkerFixture instead of beforeAll/afterAll.\n` +
-          `  - Use {auto: true} option in defineTestFixture instead of beforeEach/afterEach.`);
-    }
-    const obj = { stack: '' };
-    Error.captureStackTrace(obj);
-    const stack = obj.stack.substring('Error:\n'.length);
-    suites[0]._addHook(hookName, fn, stack);
+  const hook = (hookName: string, fixtures: FixturesImpl, fn: Function) => {
+    const suite = suites[0];
+    if (!suite.parent)
+      throw new Error(`${hookName} hook should be called inside a describe block. Consider using an auto fixture.`);
+    if (suite._fixtures !== fixtures)
+      throw new Error(`Using ${hookName} hook from a different fixture set.\nAre you using describe and ${hookName} from different fixture files?`);
+    fixtures._pool.parametersForFunction(fn, `${hookName} hook`, hookName === 'beforeEach' || hookName === 'afterEach');
   };
 
   setImplementation({
     it,
     describe,
-    beforeEach: fn => hook('beforeEach', fn),
-    afterEach: fn => hook('afterEach', fn),
-    beforeAll: fn => hook('beforeAll', fn),
-    afterAll: fn => hook('afterAll', fn),
+    beforeEach: (fixtures, fn) => hook('beforeEach', fixtures, fn),
+    afterEach: (fixtures, fn) => hook('afterEach', fixtures, fn),
+    beforeAll: (fixtures, fn) => hook('beforeAll', fixtures, fn),
+    afterAll: (fixtures, fn) => hook('afterAll', fixtures, fn),
   });
 
   return installTransform();

--- a/src/runnerTest.ts
+++ b/src/runnerTest.ts
@@ -21,19 +21,12 @@ export type ModifierFn = (modifier: TestModifier, parameters: any) => void;
 
 export class RunnerSpec extends Spec {
   _modifierFn: ModifierFn | null;
-
-  constructor(title: string, fn: Function, suite: RunnerSuite) {
-    super(title, fn, suite);
-  }
+  _usedParameters: string[];
 }
 
 export class RunnerSuite extends Suite {
   _modifierFn: ModifierFn | null;
   _hooks: { type: string, fn: Function, stack: string } [] = [];
-
-  constructor(title: string, parent?: RunnerSuite) {
-    super(title, parent);
-  }
 
   _assignIds() {
     this.findSpec((test: RunnerSpec) => {
@@ -52,10 +45,6 @@ export class RunnerTest extends Test {
   _workerHash: string;
   _id: string;
   _repeatEachIndex: number;
-
-  constructor(spec: RunnerSpec) {
-    super(spec);
-  }
 
   _appendTestResult(): TestResult {
     const result: TestResult = {

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -14,37 +14,153 @@
  * limitations under the License.
  */
 
+import { expect } from './expect';
+import { FixturePool, setParameterValues } from './fixtures';
+import { TestModifier } from './testModifier';
+
 Error.stackTraceLimit = 15;
 
 export type Implementation = {
-  it: any;
-  describe: any;
-  beforeEach: (fn: Function) => void;
-  afterEach: (fn: Function) => void;
-  beforeAll: (fn: Function) => void;
-  afterAll: (fn: Function) => void;
+  it: (spec: 'default' | 'skip' | 'only', fixtures: FixturesImpl, ...args: any[]) => void;
+  describe: (spec: 'default' | 'skip' | 'only', fixtures: FixturesImpl, ...args: any[]) => void;
+  beforeEach: (fixtures: FixturesImpl, fn: Function) => void;
+  afterEach: (fixtures: FixturesImpl, fn: Function) => void;
+  beforeAll: (fixtures: FixturesImpl, fn: Function) => void;
+  afterAll: (fixtures: FixturesImpl, fn: Function) => void;
 };
 
 let implementation: Implementation;
 
-export const it = (...args) => {
-  implementation.it('default', ...args);
-};
-it.skip = (...args) => implementation.it('skip', ...args);
-it.only = (...args) => implementation.it('only', ...args);
-export const test = it;
-
-export const describe = (...args) => {
-  implementation.describe('default', ...args);
-};
-describe.skip = (...args) => implementation.describe('skip', ...args);
-describe.only = (...args) => implementation.describe('only', ...args);
-
-export const beforeEach = fn => implementation.beforeEach(fn);
-export const afterEach = fn => implementation.afterEach(fn);
-export const beforeAll = fn => implementation.beforeAll(fn);
-export const afterAll = fn => implementation.afterAll(fn);
-
 export function setImplementation(i: Implementation) {
   implementation = i;
 }
+
+interface DescribeHelper<WorkerParameters> {
+  describe(name: string, inner: () => void): void;
+  describe(name: string, modifierFn: (modifier: TestModifier, parameters: WorkerParameters) => any, inner: () => void): void;
+}
+type DescribeFunction<WorkerParameters> = DescribeHelper<WorkerParameters>['describe'];
+interface ItHelper<WorkerParameters, WorkerFixtures, TestFixtures> {
+  it(name: string, inner: (fixtures: WorkerParameters & WorkerFixtures & TestFixtures) => Promise<void> | void): void;
+  it(name: string, modifierFn: (modifier: TestModifier, parameters: WorkerParameters) => any, inner: (fixtures: WorkerParameters & WorkerFixtures & TestFixtures) => Promise<void> | void): void;
+}
+type ItFunction<WorkerParameters, WorkerFixtures, TestFixtures> = ItHelper<WorkerParameters, WorkerFixtures, TestFixtures>['it'];
+type It<WorkerParameters, WorkerFixtures, TestFixtures> = ItFunction<WorkerParameters, WorkerFixtures, TestFixtures> & {
+  only: ItFunction<WorkerParameters, WorkerFixtures, TestFixtures>;
+  skip: ItFunction<WorkerParameters, WorkerFixtures, TestFixtures>;
+};
+type Fit<WorkerParameters, WorkerFixtures, TestFixtures> = ItFunction<WorkerParameters, WorkerFixtures, TestFixtures>;
+type Xit<WorkerParameters, WorkerFixtures, TestFixtures> = ItFunction<WorkerParameters, WorkerFixtures, TestFixtures>;
+type Describe<WorkerParameters> = DescribeFunction<WorkerParameters> & {
+  only: DescribeFunction<WorkerParameters>;
+  skip: DescribeFunction<WorkerParameters>;
+};
+type FDescribe<WorkerParameters> = DescribeFunction<WorkerParameters>;
+type XDescribe<WorkerParameters> = DescribeFunction<WorkerParameters>;
+type BeforeEach<WorkerParameters, WorkerFixtures, TestFixtures> = (inner: (fixtures: WorkerParameters & WorkerFixtures & TestFixtures) => Promise<void>) => void;
+type AfterEach<WorkerParameters, WorkerFixtures, TestFixtures> = (inner: (fixtures: WorkerParameters & WorkerFixtures & TestFixtures) => Promise<void>) => void;
+type BeforeAll<WorkerFixtures> = (inner: (fixtures: WorkerFixtures) => Promise<void>) => void;
+type AfterAll<WorkerFixtures> = (inner: (fixtures: WorkerFixtures) => Promise<void>) => void;
+
+export class FixturesImpl<WorkerParameters = {}, WorkerFixtures = {}, TestFixtures = {}> {
+  it: It<WorkerParameters, WorkerFixtures, TestFixtures>;
+  fit: Fit<WorkerParameters, WorkerFixtures, TestFixtures>;
+  xit: Xit<WorkerParameters, WorkerFixtures, TestFixtures>;
+  test: It<WorkerParameters, WorkerFixtures, TestFixtures>;
+  describe: Describe<WorkerParameters>;
+  fdescribe: FDescribe<WorkerParameters>;
+  xdescribe: XDescribe<WorkerParameters>;
+  beforeEach: BeforeEach<WorkerParameters, WorkerFixtures, TestFixtures>;
+  afterEach: AfterEach<WorkerParameters, WorkerFixtures, TestFixtures>;
+  beforeAll: BeforeAll<WorkerFixtures>;
+  afterAll: AfterAll<WorkerFixtures>;
+  expect: typeof expect;
+
+  _pool: FixturePool;
+
+  constructor(pool: FixturePool) {
+    this._pool = pool;
+    this.expect = expect;
+    this.it = ((...args: any[]) => {
+      implementation.it('default', this, ...args);
+    }) as any;
+    this.test = this.it;
+    this.it.skip = (...args: any[]) => implementation.it('skip', this, ...args);
+    this.it.only = (...args: any[]) => implementation.it('only', this, ...args);
+    this.fit = this.it.only;
+    this.xit = this.it.skip;
+    this.describe = ((...args: any[]) => {
+      implementation.describe('default', this, ...args);
+    }) as any;
+    this.describe.skip = (...args: any[]) => implementation.describe('skip', this, ...args);
+    this.describe.only = (...args: any[]) => implementation.describe('only', this, ...args);
+    this.fdescribe = this.describe.only;
+    this.xdescribe = this.describe.skip;
+    this.beforeEach = fn => implementation.beforeEach(this, fn);
+    this.afterEach = fn => implementation.afterEach(this, fn);
+    this.beforeAll = fn => implementation.beforeAll(this, fn);
+    this.afterAll = fn => implementation.afterAll(this, fn);
+  }
+
+  union<P1, W1, T1>(other1: Fixtures<P1, W1, T1>): Fixtures<WorkerParameters & P1, WorkerFixtures & W1, TestFixtures & T1>;
+  union<P1, W1, T1, P2, W2, T2>(other1: Fixtures<P1, W1, T1>, other2: Fixtures<P2, W2, T2>): Fixtures<WorkerParameters & P1 & P2, WorkerFixtures & W1 & W2, TestFixtures & T1 & T2>;
+  union<P1, W1, T1, P2, W2, T2, P3, W3, T3>(other1: Fixtures<P1, W1, T1>, other2: Fixtures<P2, W2, T2>, other3: Fixtures<P3, W3, T3>): Fixtures<WorkerParameters & P1 & P2 & P3, WorkerFixtures & W1 & W2 & W3, TestFixtures & T1 & T2 & T3>;
+  union(...others) {
+    let pool = this._pool;
+    for (const other of others)
+      pool = pool.union(other._pool);
+    return new FixturesImpl(pool);
+  }
+
+  defineTestFixtures<T extends object>(o: { [ key in keyof T]: (params: WorkerParameters & WorkerFixtures & TestFixtures & T, runTest: (value: T[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures & T> {
+    const result = new FixturesImpl(new FixturePool(this._pool));
+    for (const [ name, fixture ] of Object.entries(o))
+      result._pool.registerFixture(name, 'test', fixture as any, name.startsWith('auto'), false);
+    result._pool.checkCycles();
+    return result as any;
+  }
+
+  overrideTestFixtures(o: { [ key in keyof TestFixtures ]?: (params: WorkerParameters & WorkerFixtures & TestFixtures, runTest: (value: TestFixtures[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures> {
+    const result = new FixturesImpl(new FixturePool(this._pool));
+    for (const [ name, fixture ] of Object.entries(o))
+      result._pool.registerFixture(name, 'test', fixture as any, name.startsWith('auto'), true);
+    result._pool.checkCycles();
+    return result as any;
+  }
+
+  defineWorkerFixtures<T extends object>(o: { [ key in keyof T]: (params: WorkerParameters & WorkerFixtures & T, runTest: (value: T[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures & T, TestFixtures> {
+    const result = new FixturesImpl(new FixturePool(this._pool));
+    for (const [ name, fixture ] of Object.entries(o))
+      result._pool.registerFixture(name, 'worker', fixture as any, name.startsWith('auto'), false);
+    result._pool.checkCycles();
+    return result as any;
+  }
+
+  overrideWorkerFixtures(o: { [ key in keyof WorkerFixtures ]?: (params: WorkerParameters & WorkerFixtures, runTest: (value: WorkerFixtures[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures> {
+    const result = new FixturesImpl(new FixturePool(this._pool));
+    for (const [ name, fixture ] of Object.entries(o))
+      result._pool.registerFixture(name, 'worker', fixture as any, name.startsWith('auto'), true);
+    result._pool.checkCycles();
+    return result as any;
+  }
+
+  defineParameter<N extends string, P>(name: N, description: string, defaultValue: P): Fixtures<WorkerParameters & { [key in N] : P }, WorkerFixtures, TestFixtures> {
+    const result = new FixturesImpl(new FixturePool(this._pool));
+    result._pool.registerWorkerParameter({
+      name: name as string,
+      description,
+      defaultValue: defaultValue as any,
+    });
+    result._pool.registerFixture(name as string, 'worker', async ({}, runTest) => runTest(defaultValue), false, false);
+    return result as any;
+  }
+
+  generateParametrizedTests<T extends keyof WorkerParameters>(name: T, values: WorkerParameters[T][]) {
+    setParameterValues(name as string, values);
+  }
+}
+
+export interface Fixtures<P, W, T> extends FixturesImpl<P, W, T> {
+}
+
+export const rootFixtures = new FixturesImpl(new FixturePool(undefined)) as Fixtures<{}, {}, {}>;

--- a/src/util.ts
+++ b/src/util.ts
@@ -86,20 +86,3 @@ export function monotonicTime(): number {
   const [seconds, nanoseconds] = process.hrtime();
   return seconds * 1000 + (nanoseconds / 1000000 | 0);
 }
-
-export function callerFile(caller: Function, stackFrameIndex: number): string {
-  const obj = { stack: '' };
-  // disable source-map-support to match the locations seen in require.cache
-  const origPrepare = Error.prepareStackTrace;
-  Error.prepareStackTrace = null;
-  Error.captureStackTrace(obj, caller);
-  // v8 doesn't actually prepare the stack trace until we access it
-  obj.stack;
-  Error.prepareStackTrace = origPrepare;
-  let stackFrame = obj.stack.split('\n')[stackFrameIndex].trim();
-  if (stackFrame.startsWith('at '))
-    stackFrame = stackFrame.substring(3);
-  if (stackFrame.includes('('))
-    stackFrame = stackFrame.match(/\((.*)\)/)[1];
-  return stackFrame.replace(/^(.+):\d+:\d+$/, '$1');
-}

--- a/src/workerSpec.ts
+++ b/src/workerSpec.ts
@@ -17,7 +17,7 @@
 import { WorkerSpec, WorkerSuite } from './workerTest';
 import { installTransform } from './transform';
 import { extractLocation } from './util';
-import { setImplementation } from './spec';
+import { FixturesImpl, setImplementation } from './spec';
 import { TestModifier } from './testModifier';
 
 let currentRunSuites: WorkerSuite[];
@@ -26,17 +26,17 @@ export function workerSpec(suite: WorkerSuite): () => void {
   const suites = [suite];
   currentRunSuites = suites;
 
-  const it = (spec: 'default' | 'skip' | 'only', title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
+  const it = (spec: 'default' | 'skip' | 'only', fixtures: FixturesImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
     fn = fn || modifierFn;
-    const test = new WorkerSpec(title, fn, suites[0]);
+    const test = new WorkerSpec(fixtures, title, fn, suites[0]);
     test.file = suite.file;
     test.location = extractLocation(new Error());
     return test;
   };
 
-  const describe = (spec: 'describe' | 'skip' | 'only', title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
+  const describe = (spec: 'default' | 'skip' | 'only', fixtures: FixturesImpl, title: string, modifierFn: (modifier: TestModifier, parameters: any) => void | Function, fn?: Function) => {
     fn = fn || modifierFn;
-    const child = new WorkerSuite(title, suites[0]);
+    const child = new WorkerSuite(fixtures, title, suites[0]);
     child.file = suite.file;
     child.location = extractLocation(new Error());
     suites.unshift(child);
@@ -47,10 +47,10 @@ export function workerSpec(suite: WorkerSuite): () => void {
   setImplementation({
     it,
     describe,
-    beforeEach: fn => currentRunSuites[0]._addHook('beforeEach', fn),
-    afterEach: fn => currentRunSuites[0]._addHook('afterEach', fn),
-    beforeAll: fn => currentRunSuites[0]._addHook('beforeAll', fn),
-    afterAll: fn => currentRunSuites[0]._addHook('afterAll', fn),
+    beforeEach: (fixtures, fn) => currentRunSuites[0]._addHook('beforeEach', fn),
+    afterEach: (fixtures, fn) => currentRunSuites[0]._addHook('afterEach', fn),
+    beforeAll: (fixtures, fn) => currentRunSuites[0]._addHook('beforeAll', fn),
+    afterAll: (fixtures, fn) => currentRunSuites[0]._addHook('afterAll', fn),
   });
 
   return installTransform();

--- a/src/workerTest.ts
+++ b/src/workerTest.ts
@@ -18,18 +18,10 @@ import { Spec, Suite } from './test';
 
 export class WorkerSpec extends Spec {
   _id: string;
-
-  constructor(title: string, fn: Function, suite: WorkerSuite) {
-    super(title, fn, suite);
-  }
 }
 
 export class WorkerSuite extends Suite {
   _hooks: { type: string, fn: Function } [] = [];
-
-  constructor(title: string, parent?: WorkerSuite) {
-    super(title, parent);
-  }
 
   _assignIds(parametersString: string) {
     this.findSpec((test: WorkerSpec) => {

--- a/test/parameters.spec.ts
+++ b/test/parameters.spec.ts
@@ -64,6 +64,22 @@ it('should fail on invalid parameters', async ({ runInlineTest }) => {
   expect(result.output).toContain(`Unregistered parameter 'invalid' was set.`);
 });
 
+it('should throw on duplicate parameters globally', async ({ runInlineTest }) => {
+  const result = await runInlineTest({
+    'a.spec.ts': `
+      const f1 = fixtures.defineParameter('foo', 'Foo', '');
+      const f2 = fixtures.defineParameter('foo', 'Bar', '123');
+      f1.it('success', async ({}) => {
+      });
+      f2.it('success', async ({}) => {
+      });
+    `
+  });
+  expect(result.exitCode).toBe(1);
+  expect(result.output).toContain('a.spec.ts:6');
+  expect(result.output).toContain(`Parameter "foo" has been already registered`);
+});
+
 it('should use kebab for CLI name', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.ts': `


### PR DESCRIPTION
We now attribute each test/suite to a particular `FixturesImpl` instance, which is a new instance after every `defineTestFixtures` call.
    
Tests are sharded by workers based on the `FixturesImpl` instance and parameter values.
    
Each worker assumes that it only runs tests from a single `FixturePool`.
    
Hooks now require a describe block around them, added various error checks.