### PR TITLE
fix(parameters): default parameter fixture should work

### DIFF
--- a/src/spec.ts
+++ b/src/spec.ts
@@ -151,7 +151,7 @@ export class FixturesImpl<WorkerParameters = {}, WorkerFixtures = {}, TestFixtur
       description,
       defaultValue: defaultValue as any,
     });
-    result._pool.registerFixture(name as string, 'worker', async ({}, runTest) => runTest(defaultValue), false, false);
+    result._pool.registerFixture(name as string, 'worker', async function*() { yield defaultValue; }, false, false);
     return result as any;
   }
 

--- a/test/parameters.spec.ts
+++ b/test/parameters.spec.ts
@@ -184,3 +184,26 @@ it('tests respect automatic fixture parameters', async ({ runInlineFixturesTest 
   expect(result.exitCode).toBe(0);
   expect(result.report.suites[0].specs[0].tests[0].parameters).toEqual({ param: 'value' });
 });
+
+it('testParametersPathSegment does not throw in non-parametrized test', async ({ runInlineFixturesTest }) => {
+  const result = await runInlineFixturesTest({
+    'a.test.js': `
+      const { it } = baseFixtures
+        .defineParameter('param', 'Some param', 'value')
+        .overrideTestFixtures({
+          testParametersPathSegment: async function*({ param }) {
+            yield param;
+          }
+        });
+      it('test 1', async ({}) => {
+        expect(1).toBe(1);
+      });
+      it('test 2', async ({param}) => {
+        expect(2).toBe(2);
+      });
+    `
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.report.suites[0].specs[0].tests[0].parameters).toEqual({});
+  expect(result.report.suites[0].specs[1].tests[0].parameters).toEqual({ param: 'value' });
+});


### PR DESCRIPTION
It is called when the test does not depend on any parameters through testParametersPathSegment fixture.