### PR TITLE
Revert "api: switch from runTest(value) to yield value (#59)"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,17 +35,17 @@ type BuiltinTestFixtures = {
 };
 
 export const fixtures = rootFixtures.defineWorkerFixtures<BuiltinWorkerFixtures>({
-  testWorkerIndex: async function*() {
+  testWorkerIndex: async ({}, runTest) => {
     // Worker injects the value for this one.
-    yield 0;
+    await runTest(undefined as any);
   }
 }).defineTestFixtures<BuiltinTestFixtures>({
-  testInfo: async function*() {
+  testInfo: async ({}, runTest) => {
     // Worker injects the value for this one.
-    yield undefined as any;
+    await runTest(undefined as any);
   },
 
-  testParametersPathSegment: async function*() {
-    yield '';
+  testParametersPathSegment: async ({}, runTest) => {
+    await runTest('');
   },
 });

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -112,7 +112,7 @@ export class FixturesImpl<WorkerParameters = {}, WorkerFixtures = {}, TestFixtur
     return new FixturesImpl(pool);
   }
 
-  defineTestFixtures<T extends object>(o: { [ key in keyof T]: (params: WorkerParameters & WorkerFixtures & TestFixtures & T) => AsyncGenerator<T[key]> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures & T> {
+  defineTestFixtures<T extends object>(o: { [ key in keyof T]: (params: WorkerParameters & WorkerFixtures & TestFixtures & T, runTest: (value: T[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures & T> {
     const result = new FixturesImpl(new FixturePool(this._pool));
     for (const [ name, fixture ] of Object.entries(o))
       result._pool.registerFixture(name, 'test', fixture as any, name.startsWith('auto'), false);
@@ -120,7 +120,7 @@ export class FixturesImpl<WorkerParameters = {}, WorkerFixtures = {}, TestFixtur
     return result as any;
   }
 
-  overrideTestFixtures(o: { [ key in keyof TestFixtures ]?: (params: WorkerParameters & WorkerFixtures & TestFixtures) => AsyncGenerator<TestFixtures[key]> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures> {
+  overrideTestFixtures(o: { [ key in keyof TestFixtures ]?: (params: WorkerParameters & WorkerFixtures & TestFixtures, runTest: (value: TestFixtures[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures> {
     const result = new FixturesImpl(new FixturePool(this._pool));
     for (const [ name, fixture ] of Object.entries(o))
       result._pool.registerFixture(name, 'test', fixture as any, name.startsWith('auto'), true);
@@ -128,7 +128,7 @@ export class FixturesImpl<WorkerParameters = {}, WorkerFixtures = {}, TestFixtur
     return result as any;
   }
 
-  defineWorkerFixtures<T extends object>(o: { [ key in keyof T]: (params: WorkerParameters & WorkerFixtures & T) => AsyncGenerator<T[key]> }): Fixtures<WorkerParameters, WorkerFixtures & T, TestFixtures> {
+  defineWorkerFixtures<T extends object>(o: { [ key in keyof T]: (params: WorkerParameters & WorkerFixtures & T, runTest: (value: T[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures & T, TestFixtures> {
     const result = new FixturesImpl(new FixturePool(this._pool));
     for (const [ name, fixture ] of Object.entries(o))
       result._pool.registerFixture(name, 'worker', fixture as any, name.startsWith('auto'), false);
@@ -136,7 +136,7 @@ export class FixturesImpl<WorkerParameters = {}, WorkerFixtures = {}, TestFixtur
     return result as any;
   }
 
-  overrideWorkerFixtures(o: { [ key in keyof WorkerFixtures ]?: (params: WorkerParameters & WorkerFixtures) => AsyncGenerator<WorkerFixtures[key]> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures> {
+  overrideWorkerFixtures(o: { [ key in keyof WorkerFixtures ]?: (params: WorkerParameters & WorkerFixtures, runTest: (value: WorkerFixtures[key]) => Promise<void>) => Promise<void> }): Fixtures<WorkerParameters, WorkerFixtures, TestFixtures> {
     const result = new FixturesImpl(new FixturePool(this._pool));
     for (const [ name, fixture ] of Object.entries(o))
       result._pool.registerFixture(name, 'worker', fixture as any, name.startsWith('auto'), true);
@@ -151,7 +151,7 @@ export class FixturesImpl<WorkerParameters = {}, WorkerFixtures = {}, TestFixtur
       description,
       defaultValue: defaultValue as any,
     });
-    result._pool.registerFixture(name as string, 'worker', async function*() { yield defaultValue; }, false, false);
+    result._pool.registerFixture(name as string, 'worker', async ({}, runTest) => runTest(defaultValue), false, false);
     return result as any;
   }
 

--- a/test/assets/export-1.fixtures.ts
+++ b/test/assets/export-1.fixtures.ts
@@ -24,11 +24,11 @@ type WrapTestState = {
 };
 
 export const fixtures1 = baseFixtures.defineTestFixtures<WrapTestState>({
-  testWrap: async function*() {
-    yield 'testWrap';
+  testWrap: async ({}, runTest) => {
+    await runTest('testWrap');
   }
 }).defineWorkerFixtures<WrapWorkerState>({
-  workerWrap: async function*() {
-    yield 42;
+  workerWrap: async ({}, runTest) => {
+    await runTest(42);
   }
 });

--- a/test/assets/export-2.fixtures.ts
+++ b/test/assets/export-2.fixtures.ts
@@ -24,11 +24,11 @@ type TypeOnlyWorkerState = {
 };
 
 export const fixtures2 = baseFixtures.defineTestFixtures<TypeOnlyTestState>({
-  testTypeOnly: async function*() {
-    yield 'testTypeOnly';
+  testTypeOnly: async ({}, runTest) => {
+    await runTest('testTypeOnly');
   }
 }).defineWorkerFixtures<TypeOnlyWorkerState>({
-  workerTypeOnly: async function*() {
-    yield 42;
+  workerTypeOnly: async ({}, runTest) => {
+    await runTest(42);
   }
 });

--- a/test/assets/import-fixtures-both.ts
+++ b/test/assets/import-fixtures-both.ts
@@ -19,12 +19,12 @@ import { fixtures2 } from './export-2.fixtures';
 
 const fixtures = fixtures1.union(fixtures2);
 const { it, expect } = fixtures.overrideTestFixtures({
-  testWrap: async function*() {
-    yield 'override';
+  testWrap: async ({}, runTest) => {
+    await runTest('override');
   }
 }).overrideWorkerFixtures({
-  workerTypeOnly: async function*() {
-    yield 17;
+  workerTypeOnly: async ({}, runTest) => {
+    await runTest(17);
   }
 });
 

--- a/test/assets/register-parameter.ts
+++ b/test/assets/register-parameter.ts
@@ -20,11 +20,11 @@ const { it } = baseFixtures
     .defineParameter<'param1', string>('param1', 'Custom parameter 1', '')
     .defineParameter<'param2', string>('param2', 'Custom parameter 2', 'value2')
     .defineTestFixtures<{ fixture1: string, fixture2: string}>({
-      fixture1: async function*({ testInfo }) {
-        yield testInfo.parameters.param1 as string;
+      fixture1: async ({testInfo}, runTest) => {
+        await runTest(testInfo.parameters.param1 as string);
       },
-      fixture2: async function*({ testInfo }) {
-        yield testInfo.parameters.param2 as string;
+      fixture2: async ({testInfo}, runTest) => {
+        await runTest(testInfo.parameters.param2 as string);
       },
     });
 

--- a/test/assets/test-data-visible-in-fixture.ts
+++ b/test/assets/test-data-visible-in-fixture.ts
@@ -17,8 +17,8 @@
 import { config, fixtures, TestInfo } from '../../';
 
 const { it, expect } = fixtures.defineTestFixtures<{ testInfoForward: TestInfo }>({
-  testInfoForward: async function*({ testInfo }) {
-    yield testInfo;
+  testInfoForward: async ({ testInfo }, runTest) => {
+    await runTest(testInfo);
     testInfo.data['myname'] = 'myvalue';
   },
 });

--- a/test/assets/test-error-visible-in-fixture.ts
+++ b/test/assets/test-error-visible-in-fixture.ts
@@ -17,8 +17,8 @@
 import { fixtures } from '../../';
 
 const { it, expect } = fixtures.defineTestFixtures<{ postProcess: string }>({
-  postProcess: async function*({ testInfo }) {
-    yield '';
+  postProcess: async ({testInfo}, runTest) => {
+    await runTest('');
     console.log('ERROR[[[' + JSON.stringify(testInfo.error, undefined, 2) + ']]]');
   },
 });

--- a/test/fixture-errors.spec.ts
+++ b/test/fixture-errors.spec.ts
@@ -21,8 +21,8 @@ it('should handle fixture timeout', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
       const { it } = baseFixtures.defineTestFixtures({
-        timeout: async function*() {
-          yield undefined;
+        timeout: async ({}, runTest) => {
+          await runTest();
           await new Promise(f => setTimeout(f, 100000));
         },
       });
@@ -45,10 +45,8 @@ it('should handle worker fixture timeout', async ({ runInlineFixturesTest }) => 
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
       const { it } = baseFixtures.defineWorkerFixtures({
-        timeout: async function*() {
-          await new Promise(f => setTimeout(f, 100000));
-          yield undefined;
-        }
+        timeout: async ({}, runTest) => {
+        },
       });
 
       it('fails', async ({timeout}) => {
@@ -63,7 +61,7 @@ it('should handle worker fixture error', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
       const { it } = baseFixtures.defineWorkerFixtures({
-        failure: async function*() {
+        failure: async ({}, runTest) => {
           throw new Error('Worker failed');
         },
       });
@@ -81,8 +79,8 @@ it('should handle worker tear down fixture error', async ({ runInlineFixturesTes
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
       const { it } = baseFixtures.defineWorkerFixtures({
-        failure: async function*() {
-          yield undefined;
+        failure: async ({}, runTest) => {
+          await runTest();
           throw new Error('Worker failed');
         },
       });
@@ -100,7 +98,9 @@ it('should throw when overriding non-defined worker fixture', async ({ runInline
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
       const { it } = baseFixtures.overrideWorkerFixtures({
-        foo: async function*() { yield undefined; }
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       it('works', async ({foo}) => {});
     `
@@ -113,10 +113,14 @@ it('should throw when defining worker fixture twice', async ({ runInlineFixtures
   const result = await runInlineFixturesTest({
     'b.spec.ts': `
       const f1 = baseFixtures.defineWorkerFixtures({
-        foo: async function*() { yield undefined; }
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       const { it } = f1.defineWorkerFixtures({
-        foo: async function*() { yield undefined; }
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       it('works', async ({foo}) => {});
     `
@@ -129,7 +133,9 @@ it('should throw when overriding non-defined test fixture', async ({ runInlineFi
   const result = await runInlineFixturesTest({
     'c.spec.ts': `
       const { it } = baseFixtures.overrideTestFixtures({
-        foo: async function*() { yield undefined; }
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       it('works', async ({foo}) => {});
     `
@@ -142,10 +148,14 @@ it('should throw when defining test fixture twice', async ({ runInlineFixturesTe
   const result = await runInlineFixturesTest({
     'd.spec.ts': `
       const f1 = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield undefined; }
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       const { it } = f1.defineTestFixtures({
-        foo: async function*() { yield undefined; }
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       it('works', async ({foo}) => {});
     `
@@ -157,11 +167,11 @@ it('should throw when defining test fixture twice', async ({ runInlineFixturesTe
 it('should throw when defining test fixture with the same name as a worker fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'e.spec.ts': `
-      const { it } = baseFixtures.defineWorkerFixtures({
-        foo: async function*() { yield undefined; }
-      }).defineTestFixtures({
-        foo: async function*() { yield undefined; }
-      });
+      const { it } = baseFixtures.defineWorkerFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } }).defineTestFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } });
       it('works', async ({foo}) => {});
     `,
   });
@@ -172,11 +182,11 @@ it('should throw when defining test fixture with the same name as a worker fixtu
 it('should throw when defining worker fixture with the same name as a test fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'e.spec.ts': `
-      const { it } = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield undefined; }
-      }).defineWorkerFixtures({
-        foo: async function*() { yield undefined; }
-      });
+      const { it } = baseFixtures.defineTestFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } }).defineWorkerFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } });
       it('works', async ({foo}) => {});
     `,
   });
@@ -187,11 +197,11 @@ it('should throw when defining worker fixture with the same name as a test fixtu
 it('should throw when overriding worker fixture as a test fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'f.spec.ts': `
-      const { it } = baseFixtures.defineWorkerFixtures({
-        foo: async function*() { yield undefined; }
-      }).overrideTestFixtures({
-        foo: async function*() { yield undefined; }
-      });
+      const { it } = baseFixtures.defineWorkerFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } }).overrideTestFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } });
       it('works', async ({foo}) => {});
     `,
   });
@@ -202,11 +212,11 @@ it('should throw when overriding worker fixture as a test fixture', async ({ run
 it('should throw when overriding test fixture as a worker fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'f.spec.ts': `
-      const { it } = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield undefined; }
-      }).overrideWorkerFixtures({
-        foo: async function*() { yield undefined; }
-      });
+      const { it } = baseFixtures.defineTestFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } }).overrideWorkerFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } });
       it('works', async ({foo}) => {});
     `,
   });
@@ -218,11 +228,11 @@ it('should throw when overriding test fixture as a worker fixture', async ({ run
 it('should throw when worker fixture depends on a test fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'f.spec.ts': `
-      const { it } = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield undefined; }
-      }).defineWorkerFixtures({
-        bar: async function*({ foo }) { yield undefined; }
-      });
+      const { it } = baseFixtures.defineTestFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } }).defineWorkerFixtures({ bar: async ({foo}, runTest) => {
+        await runTest();
+      } });
       it('works', async ({bar}) => {});
     `,
   });
@@ -233,19 +243,19 @@ it('should throw when worker fixture depends on a test fixture', async ({ runInl
 it('should define and override the same fixture in two files', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const { it } = baseFixtures.defineWorkerFixtures({
-        foo: async function*() { yield undefined; }
-      }).overrideWorkerFixtures({
-        foo: async function*() { yield undefined; }
-      });
+      const { it } = baseFixtures.defineWorkerFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } }).overrideWorkerFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } });
       it('works', async ({foo}) => {});
     `,
     'b.spec.ts': `
-      const { it } = baseFixtures.defineWorkerFixtures({
-        foo: async function*() { yield undefined; }
-      }).overrideWorkerFixtures({
-        foo: async function*() { yield undefined; }
-      });
+      const { it } = baseFixtures.defineWorkerFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } }).overrideWorkerFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } });
       it('works', async ({foo}) => {});
     `,
   });
@@ -257,12 +267,24 @@ it('should detect fixture dependency cycle', async ({ runInlineFixturesTest }) =
   const result = await runInlineFixturesTest({
     'x.spec.ts': `
       const { it } = baseFixtures.defineTestFixtures({
-        good1: async function*() { yield undefined; },
-        foo: async function*({ bar} ) { yield undefined; },
-        bar: async function*({ baz }) { yield undefined; },
-        good2: async function*({ good1 }) { yield undefined; },
-        baz: async function*({ qux }) { yield undefined; },
-        qux: async function*({ foo }) { yield undefined; },
+        good1: async ({}, runTest) => {
+          await runTest();
+        },
+        foo: async ({bar}, runTest) => {
+          await runTest();
+        },
+        bar: async ({baz}, runTest) => {
+          await runTest();
+        },
+        good2: async ({good1}, runTest) => {
+          await runTest();
+        },
+        baz: async ({qux}, runTest) => {
+          await runTest();
+        },
+        qux: async ({foo}, runTest) => {
+          await runTest();
+        }
       });
       it('works', async ({foo}) => {});
     `,
@@ -275,14 +297,15 @@ it('should throw when fixture is redefined in union', async ({ runInlineFixtures
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const fixtures1 = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield 123; }
+        foo: async ({}, test) => await test(123)
       });
       const fixtures2 = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield 456; }
+        foo: async ({}, test) => await test(456)
       });
       const { it } = fixtures1.union(fixtures2);
-      it('test', async ({foo}) => {
+      it('test', async ({foo, bar}) => {
         expect(foo).toBe(123);
+        expect(bar).toBe(456);
       });
     `,
   });
@@ -294,10 +317,10 @@ it('should throw when mixing different fixture objects', async ({ runInlineFixtu
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const fixtures1 = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield 123; }
+        foo: async ({}, test) => await test(123)
       });
       const fixtures2 = baseFixtures.defineTestFixtures({
-        bar: async function*() { yield 456; }
+        bar: async ({}, test) => await test(456)
       });
       fixtures1.describe('suite', () => {
         fixtures1.it('test 1', async ({foo}) => {
@@ -317,7 +340,9 @@ it('should not reuse fixtures from one file in another one', async ({ runInlineF
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
       const { it } = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield undefined; }
+        foo: async ({}, runTest) => {
+          await runTest();
+        },
       });
       it('test1', async ({}) => {});
     `,

--- a/test/fixtures.spec.ts
+++ b/test/fixtures.spec.ts
@@ -21,7 +21,7 @@ it('should work', async ({ runInlineFixturesTest }) => {
   const { results } = await runInlineFixturesTest({
     'a.test.js': `
       const { it } = baseFixtures.defineTestFixtures({
-        asdf: async function*() { yield 123; }
+        asdf: async ({}, test) => await test(123)
       });
       it('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(123);
@@ -35,7 +35,7 @@ it('should work with a sync function', async ({ runInlineFixturesTest }) => {
   const { results } = await runInlineFixturesTest({
     'a.test.js': `
       const { it } = baseFixtures.defineTestFixtures({
-        asdf: async function*() { yield 123; }
+        asdf: async ({}, test) => await test(123)
       });
       it('should use asdf', ({asdf}) => {
         expect(asdf).toBe(123);
@@ -49,7 +49,7 @@ it('should work with a non-arrow function', async ({ runInlineFixturesTest }) =>
   const { results } = await runInlineFixturesTest({
     'a.test.js': `
       const { it } = baseFixtures.defineTestFixtures({
-        asdf: async function*() { yield 123; }
+        asdf: async ({}, test) => await test(123)
       });
       it('should use asdf', function ({asdf}) {
         expect(asdf).toBe(123);
@@ -63,7 +63,7 @@ it('should work with a named function', async ({ runInlineFixturesTest }) => {
   const { results } = await runInlineFixturesTest({
     'a.test.js': `
       const { it } = baseFixtures.defineTestFixtures({
-        asdf: async function*() { yield 123; }
+        asdf: async ({}, test) => await test(123)
       });
       it('should use asdf', async function hello({asdf}) {
         expect(asdf).toBe(123);
@@ -77,7 +77,7 @@ it('should work with renamed parameters', async ({ runInlineFixturesTest }) => {
   const { results } = await runInlineFixturesTest({
     'a.test.js': `
       const { it } = baseFixtures.defineTestFixtures({
-        asdf: async function*() { yield 123; }
+        asdf: async ({}, test) => await test(123)
       });
       it('should use asdf', function ({asdf: renamed}) {
         expect(renamed).toBe(123);
@@ -91,7 +91,7 @@ it('should fail if parameters are not destructured', async ({ runInlineFixturesT
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const { it } = baseFixtures.defineTestFixtures({
-        asdf: async function*() { yield 123; }
+        asdf: async ({}, test) => await test(123)
       });
       it('should pass', function () {
         expect(1).toBe(1);
@@ -124,7 +124,7 @@ it('should run the fixture every time', async ({ runInlineFixturesTest }) => {
     'a.test.js': `
       let counter = 0;
       const { it } = baseFixtures.defineTestFixtures({
-        asdf: async function*() { yield counter++; }
+        asdf: async ({}, test) => await test(counter++)
       });
       it('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(0);
@@ -145,7 +145,7 @@ it('should only run worker fixtures once', async ({ runInlineFixturesTest }) => 
     'a.test.js': `
       let counter = 0;
       const { it } = baseFixtures.defineWorkerFixtures({
-        asdf: async function*() { yield counter++; }
+        asdf: async ({}, test) => await test(counter++)
       });
       it('should use asdf', async ({asdf}) => {
         expect(asdf).toBe(0);
@@ -165,9 +165,9 @@ it('each file should get their own fixtures', async ({ runInlineFixturesTest }) 
   const { results } = await runInlineFixturesTest({
     'a.test.js': `
       const { it } = baseFixtures.defineWorkerFixtures({
-        worker: async function*() { yield 'worker-a'; }
+        worker: async ({}, test) => await test('worker-a'),
       }).defineTestFixtures({
-        test: async function*() { yield 'test-a'; }
+        test: async ({}, test) => await test('test-a'),
       });
       it('should use worker', async ({worker, test}) => {
         expect(worker).toBe('worker-a');
@@ -176,9 +176,9 @@ it('each file should get their own fixtures', async ({ runInlineFixturesTest }) 
     `,
     'b.test.js': `
       const { it } = baseFixtures.defineWorkerFixtures({
-        worker: async function*() { yield 'worker-b'; }
+        worker: async ({}, test) => await test('worker-b'),
       }).defineTestFixtures({
-        test: async function*() { yield 'test-b'; }
+        test: async ({}, test) => await test('test-b'),
       });
       it('should use worker', async ({worker, test}) => {
         expect(worker).toBe('worker-b');
@@ -187,9 +187,9 @@ it('each file should get their own fixtures', async ({ runInlineFixturesTest }) 
     `,
     'c.test.js': `
       const { it } = baseFixtures.defineWorkerFixtures({
-        worker: async function*() { yield 'worker-c'; }
+        worker: async ({}, test) => await test('worker-c'),
       }).defineTestFixtures({
-        test: async function*() { yield 'test-c'; }
+        test: async ({}, test) => await test('test-c'),
       });
       it('should use worker', async ({worker, test}) => {
         expect(worker).toBe('worker-c');
@@ -205,7 +205,7 @@ it('tests should be able to share worker fixtures', async ({ runInlineFixturesTe
     'worker.js': `
       global.counter = 0;
       module.exports = baseFixtures.defineWorkerFixtures({
-        worker: async function*() { yield global.counter++; }
+        worker: async ({}, test) => await test(global.counter++)
       });
     `,
     'a.test.js': `
@@ -235,7 +235,10 @@ it('tests respect automatic test fixtures', async ({ runInlineFixturesTest }) =>
     'a.test.js': `
       let counter = 0;
       const { it } = baseFixtures.defineTestFixtures({
-        automaticTestFixture: async function*() { ++counter; yield; }
+        automaticTestFixture: async ({}, runTest) => {
+          ++counter;
+          await runTest();
+        },
       });
       it('test 1', async ({}) => {
         expect(counter).toBe(1);
@@ -254,7 +257,10 @@ it('tests respect automatic worker fixtures', async ({ runInlineFixturesTest }) 
     'a.test.js': `
       let counter = 0;
       const { it } = baseFixtures.defineWorkerFixtures({
-        automaticWorkerFixture: async function*() { ++counter; yield; }
+        automaticWorkerFixture: async ({}, runTest) => {
+          ++counter;
+          await runTest();
+        },
       });
       it('test 1', async ({}) => {
         expect(counter).toBe(1);
@@ -273,7 +279,10 @@ it('tests does not run non-automatic worker fixtures', async ({ runInlineFixture
     'a.test.js': `
       let counter = 0;
       const { it } = baseFixtures.defineTestFixtures({
-        nonAutomaticWorkerFixture: async function*() { ++counter; yield; }
+        nonAutomaticWorkerFixture: async ({}, runTest) => {
+          ++counter;
+          await runTest();
+        },
       });
       it('test 1', async ({}) => {
         expect(counter).toBe(0);
@@ -292,13 +301,13 @@ it('should teardown fixtures after timeout', async ({ runInlineFixturesTest, tes
       const { it } = baseFixtures
         .defineParameter('file', 'File', '')
         .defineTestFixtures({
-          t: async function*({ file }) {
-            yield 't';
+          t: async ({ file }, runTest) => {
+            await runTest('t');
             require('fs').appendFileSync(file, 'test fixture teardown\\n', 'utf8');
           }
         }).defineWorkerFixtures({
-          w: async function*({ file }) {
-            yield 'w';
+          w: async ({ file }, runTest) => {
+            await runTest('w');
             require('fs').appendFileSync(file, 'worker fixture teardown\\n', 'utf8');
           }
         });
@@ -319,10 +328,10 @@ it('should work with two different fixture objects', async ({ runInlineFixturesT
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const fixtures1 = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield 123; }
+        foo: async ({}, test) => await test(123)
       });
       const fixtures2 = baseFixtures.defineTestFixtures({
-        bar: async function*() { yield 456; }
+        bar: async ({}, test) => await test(456)
       });
       fixtures1.it('test 1', async ({foo}) => {
         expect(foo).toBe(123);
@@ -342,10 +351,10 @@ it('should work with fixtures union', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const fixtures1 = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield 123; }
+        foo: async ({}, test) => await test(123)
       });
       const fixtures2 = baseFixtures.defineTestFixtures({
-        bar: async function*() { yield 456; }
+        bar: async ({}, test) => await test(456)
       });
       const { it } = fixtures1.union(fixtures2);
       it('test', async ({foo, bar}) => {

--- a/test/hooks.spec.ts
+++ b/test/hooks.spec.ts
@@ -21,13 +21,13 @@ it('hooks should work with fixtures', async ({ runInlineFixturesTest }) => {
   const { results } = await runInlineFixturesTest({
     'a.test.js': `
       const logs = [];
-      const fixtures = baseFixtures.defineWorkerFixtures({ w: async function*() {
+      const fixtures = baseFixtures.defineWorkerFixtures({ w: async ({}, test) => {
         logs.push('+w');
-        yield 17;
+        await test(17);
         logs.push('-w');
-      } }).defineTestFixtures({ t: async function*() {
+      } }).defineTestFixtures({ t: async ({}, test) => {
         logs.push('+t');
-        yield 42;
+        await test(42);
         logs.push('-t');
       } });
 
@@ -75,9 +75,9 @@ it('hooks should work with fixtures', async ({ runInlineFixturesTest }) => {
 it('afterEach failure should not prevent other hooks and fixture teardown', async ({ runInlineFixturesTest }) => {
   const report = await runInlineFixturesTest({
     'a.test.js': `
-      const fixtures = baseFixtures.defineTestFixtures({ t: async function*() {
+      const fixtures = baseFixtures.defineTestFixtures({ t: async ({}, test) => {
         console.log('+t');
-        yield 42;
+        await test(42);
         console.log('-t');
       } });
       fixtures.describe('suite', () => {
@@ -167,9 +167,9 @@ it('should throw when hook depends on unknown fixture', async ({ runInlineFixtur
 it('should throw when beforeAll hook depends on test fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const { it, beforeAll, describe } = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield undefined; }
-      });
+      const { it, beforeAll, describe } = baseFixtures.defineTestFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } });
       describe('suite', () => {
         beforeAll(async ({foo}) => {});
         it('works', async ({foo}) => {});
@@ -184,9 +184,9 @@ it('should throw when beforeAll hook depends on test fixture', async ({ runInlin
 it('should throw when afterAll hook depends on test fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const { it, afterAll, describe } = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield undefined; }
-      });
+      const { it, afterAll, describe } = baseFixtures.defineTestFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } });
       describe('suite', () => {
         afterAll(async ({foo}) => {});
         it('works', async ({foo}) => {});
@@ -201,12 +201,12 @@ it('should throw when afterAll hook depends on test fixture', async ({ runInline
 it('should throw when hook uses different fixtures set than describe', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.spec.ts': `
-      const f1 = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield undefined; }
-      });
-      const f2 = baseFixtures.defineTestFixtures({
-        bar: async function*() { yield undefined; }
-      });
+      const f1 = baseFixtures.defineTestFixtures({ foo: async ({}, runTest) => {
+        await runTest();
+      } });
+      const f2 = baseFixtures.defineTestFixtures({ bar: async ({}, runTest) => {
+        await runTest();
+      } });
       f1.describe('suite', () => {
         f2.afterAll(async ({foo}) => {});
         f1.it('works', async ({foo}) => {});

--- a/test/override-fixtures.spec.ts
+++ b/test/override-fixtures.spec.ts
@@ -21,17 +21,17 @@ it('should respect require order', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'fixture.js': `
       exports.fixtures = baseFixtures.defineWorkerFixtures({
-        fixture: async function*() { yield 'base'; }
+        fixture: ({}, runTest) => runTest('base')
       });
     `,
     'override1.js': `
       exports.fixtures = require('./fixture.js').fixtures.overrideWorkerFixtures({
-        fixture: async function*() { yield 'override1'; }
+        fixture: ({}, runTest) => runTest('override1')
       });
     `,
     'override2.js': `
       exports.fixtures = require('./fixture.js').fixtures.overrideWorkerFixtures({
-        fixture: async function*() { yield 'override2'; }
+        fixture: ({}, runTest) => runTest('override2')
       });
     `,
     'a.test.js': `
@@ -80,17 +80,17 @@ it('should respect override order 2', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'fixture.js': `
       module.exports = baseFixtures.defineWorkerFixtures({
-        fixture: async function*() { yield 'base'; }
+        fixture: ({}, runTest) => runTest('base')
       });
     `,
     'override1.js': `
       module.exports = fixtures => fixtures.overrideWorkerFixtures({
-        fixture: async function*() { yield 'override1'; }
+        fixture: ({}, runTest) => runTest('override1')
       });
     `,
     'override2.js': `
       module.exports = fixtures => fixtures.overrideWorkerFixtures({
-        fixture: async function*() { yield 'override2'; }
+        fixture: ({}, runTest) => runTest('override2')
       });
     `,
     'a.test.js': `
@@ -147,13 +147,13 @@ it('should allow overrides in union', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'fixtures.js': `
       const base = baseFixtures.defineTestFixtures({
-        foo: async function*() { yield 'base'; }
+        foo: async ({}, runTest) => { await runTest('base') }
       });
       const fixtures1 = base.defineTestFixtures({
-        bar: async function*() { yield 'bar'; }
+        bar: async ({}, runTest) => { await runTest('bar') }
       });
       const fixtures2 = base.overrideTestFixtures({
-        foo: async function*() { yield 'override'; }
+        foo: async ({}, runTest) => { await runTest('override') }
       });
       module.exports = { fixtures1, fixtures2 };
     `,
@@ -168,7 +168,7 @@ it('should allow overrides in union', async ({ runInlineFixturesTest }) => {
         expect(bar).toBe('bar');
       });
       fixtures2.union(fixtures1).overrideTestFixtures({
-        foo: async function*() { yield 'local'; }
+        foo: async ({}, runTest) => { await runTest('local') }
       }).it('test3', ({ foo, bar }) => {
         expect(foo).toBe('local');
         expect(bar).toBe('bar');

--- a/test/parameters.spec.ts
+++ b/test/parameters.spec.ts
@@ -171,11 +171,9 @@ it('tests respect automatic fixture parameters', async ({ runInlineFixturesTest 
     'a.test.js': `
       const { it } = baseFixtures
         .defineParameter('param', 'Some param', 'value')
-        .defineTestFixtures({
-          automaticTestFixture: async function*({ param }) {
-            yield param;
-          }
-        });
+        .defineTestFixtures({ automaticTestFixture: async ({param}, runTest) => {
+          await runTest(param);
+        } });
       it('test 1', async ({}) => {
         expect(1).toBe(1);
       });
@@ -191,8 +189,8 @@ it('testParametersPathSegment does not throw in non-parametrized test', async ({
       const { it } = baseFixtures
         .defineParameter('param', 'Some param', 'value')
         .overrideTestFixtures({
-          testParametersPathSegment: async function*({ param }) {
-            yield param;
+          testParametersPathSegment: async ({ param }, runTest) => {
+            await runTest(param);
           }
         });
       it('test 1', async ({}) => {

--- a/test/stdio.spec.ts
+++ b/test/stdio.spec.ts
@@ -40,9 +40,9 @@ it('should get top level stdio', async ({runInlineTest}) => {
 it('should get stdio from worker fixture teardown', async ({runInlineFixturesTest}) => {
   const result = await runInlineFixturesTest({
     'a.spec.js': `
-      const { it } = baseFixtures.defineWorkerFixtures({ fixture: async function*() {
+      const { it } = baseFixtures.defineWorkerFixtures({ fixture: async ({}, runTest) => {
         console.log('\\n%% worker setup');
-        yield undefined;
+        await runTest();
         console.log('\\n%% worker teardown');
       } });
       it('is a test', async ({fixture}) => {});

--- a/test/test-info-fixture.spec.ts
+++ b/test/test-info-fixture.spec.ts
@@ -35,7 +35,7 @@ it('should work via fixture', async ({ runInlineFixturesTest }) => {
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const { it } = baseFixtures.defineTestFixtures({
-        title: async function*({ testInfo }) { yield testInfo.title; }
+        title: async ({testInfo}, test) => await test(testInfo.title)
       });
       it('test 1', async ({title}) => {
         expect(title).toBe('test 1');

--- a/test/worker-index.spec.ts
+++ b/test/worker-index.spec.ts
@@ -50,8 +50,8 @@ it('should reuse worker for the same parameters', async ({ runInlineFixturesTest
   const result = await runInlineFixturesTest({
     'a.test.js': `
       const { it } = baseFixtures.defineWorkerFixtures({
-        worker1: async function*() { yield null; },
-        worker2: async function*() { yield null; },
+        worker1: ({}, runTest) => runTest(),
+        worker2: ({}, runTest) => runTest(),
       });
 
       it('succeeds', async ({ worker1, testWorkerIndex }) => {


### PR DESCRIPTION
Turned out to be less convenient.